### PR TITLE
Add blog to the site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@
 source "https://rubygems.org"
 
 gem "middleman", "~>3.3.12"
+gem "middleman-blog", "~> 3.5.3"
+gem "middleman-syntax"
+gem "redcarpet"
 gem "middleman-s3_sync"
 gem "susy"
 gem "bourbon"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     ansi (1.5.0)
     bourbon (4.2.2)
       sass (~> 3.4)
@@ -83,6 +84,10 @@ GEM
       middleman-sprockets (>= 3.1.2)
       sass (>= 3.4.0, < 4.0)
       uglifier (~> 2.5)
+    middleman-blog (3.5.3)
+      addressable (~> 2.3.5)
+      middleman-core (~> 3.2)
+      tzinfo (>= 0.3.0)
     middleman-core (3.3.12)
       activesupport (~> 4.1.0)
       bundler (~> 1.1)
@@ -108,6 +113,9 @@ GEM
       sprockets (~> 2.12.1)
       sprockets-helpers (~> 1.1.0)
       sprockets-sass (~> 1.3.0)
+    middleman-syntax (2.0.0)
+      middleman-core (~> 3.2)
+      rouge (~> 1.0)
     mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (5.6.1)
@@ -130,6 +138,8 @@ GEM
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
+    redcarpet (3.3.2)
+    rouge (1.9.1)
     ruby-progressbar (1.7.5)
     sass (3.4.13)
     sassy-maps (0.4.0)
@@ -168,5 +178,8 @@ DEPENDENCIES
   bourbon
   breakpoint
   middleman (~> 3.3.12)
+  middleman-blog (~> 3.5.3)
   middleman-s3_sync
+  middleman-syntax
+  redcarpet
   susy

--- a/config.rb
+++ b/config.rb
@@ -3,6 +3,16 @@
 # Page options, layouts, aliases and proxies
 ###
 
+activate :blog do |blog|
+  blog.prefix = "blog"
+  blog.layout = "blog_layout"
+end
+
+activate :syntax
+
+set :markdown_engine, :redcarpet
+set :markdown, :fenced_code_blocks => true, :smartypants => true
+
 # Per-page layout changes:
 #
 # With no layout

--- a/source/blog/2015-07-17-api-security-vulnerability.html.markdown
+++ b/source/blog/2015-07-17-api-security-vulnerability.html.markdown
@@ -1,0 +1,36 @@
+---
+title: Spree API Security Vulnerability
+date: 2015-07-17
+tags: security, api
+author: John Hawthorn
+---
+
+On Friday we came across a serious security vulnerability in the Spree/Solidus API.
+The effect of this vulnerability is that an attacker is able to access any file
+on the system. A valid API key is not required to exploit this.
+
+All users should patch their servers immediately. We've provided the following
+monkey patch to remove the vulnerability. This should be put in a initializer,
+for example: `config/initializers/spree_api_template_security.rb`.
+
+``` ruby
+module Spree::Api::Responders::RablTemplate
+  def template
+    options[:default_template]
+  end
+end
+```
+
+We also have provided the fix [as a
+patch](https://gist.github.com/jhawthorn/85e8d707a1b871f11cfd).
+
+This affects **all versions** of spree (1.3 and up) and solidus 1.0.0.pre.
+This has been fixed on the [solidus
+master](http://github.com/solidusio/solidus) and in
+[1.0.0.pre2](https://rubygems.org/gems/solidus/versions/1.0.0.pre2).
+
+It is likely that this remote file access can be leveraged to execute arbitrary
+code, and should be treated as such. Servers and databases should be assumed to
+have been compromised.  We recommend everyone replace all security credentials
+including database passwords, ssh keys, payment gateway credentials, API
+tokens, and passwords.

--- a/source/blog/index.html.erb
+++ b/source/blog/index.html.erb
@@ -1,0 +1,26 @@
+---
+pageable: true
+per_page: 10
+---
+<% if paginate && num_pages > 1 %>
+  <p>Page <%= page_number %> of <%= num_pages %></p>
+
+  <% if prev_page %>
+    <p><%= link_to 'Previous page', prev_page %></p>
+  <% end %>
+<% end %>
+
+<% page_articles.each_with_index do |article, i| %>
+  <article>
+  <h2><%= link_to article.title, article %> <span><%= article.date.strftime('%b %e') %></span></h2>
+  <!-- use article.summary(250) if you have Nokogiri available to show just
+       the first 250 characters -->
+  <%= article.body %>
+  </article>
+<% end %>
+
+<% if paginate %>
+  <% if next_page %>
+    <p><%= link_to 'Next page', next_page %></p>
+  <% end %>
+<% end %>

--- a/source/layouts/blog_layout.erb
+++ b/source/layouts/blog_layout.erb
@@ -1,0 +1,23 @@
+<% wrap_layout :layout do %>
+  <article>
+    <h1><%= current_article.title %></h1>
+    <div class="byline">
+      <% if author = current_article.data[:author] %>
+        by <span class="author"><%= author %></span>
+      <% end %>
+      on <span class="date"><%= current_article.date.strftime('%b %e') %></span>
+    </div>
+    <div class="content">
+      <%= yield %>
+    </div>
+  </article>
+
+  <aside>
+    <h2>Recent Articles</h2>
+    <ol>
+      <% blog.articles[0...10].each do |article| %>
+        <li><%= link_to article.title, article %> <span><%= article.date.strftime('%b %e') %></span></li>
+      <% end %>
+    </ol>
+  </aside>
+<% end %>

--- a/source/partials/_header.html.erb
+++ b/source/partials/_header.html.erb
@@ -5,6 +5,7 @@
     <% end %>
 
     <ul>
+      <li><%= link_to "Blog", "/blog" %></li>
       <li><a href="http://docs.solidus.io/">Documentation</a></li>
       <li><a href="https://github.com/solidusio/solidus">Github</a></li>
     </ul>

--- a/source/stylesheets/components/_snippets.scss
+++ b/source/stylesheets/components/_snippets.scss
@@ -11,3 +11,10 @@ pre {
 code {
   color: $color-primary;
 }
+
+/* code within a pre should be rendered as normal */
+pre code {
+  border: none;
+  background: none;
+  color: $color-secondary;
+}

--- a/source/stylesheets/components/_syntax.scss.erb
+++ b/source/stylesheets/components/_syntax.scss.erb
@@ -1,0 +1,1 @@
+<%= Rouge::Themes::Github.render(:scope => '.highlight') %>

--- a/source/stylesheets/pages/_blog.scss
+++ b/source/stylesheets/pages/_blog.scss
@@ -1,0 +1,13 @@
+body.blog {
+  article, aside {
+    max-width: 900px;
+    margin: auto;
+  }
+}
+
+.byline {
+  font-style: italic;
+  .author, .date {
+    font-style: normal;
+  }
+}

--- a/source/stylesheets/solidus.scss
+++ b/source/stylesheets/solidus.scss
@@ -12,8 +12,10 @@
 @import "components/forms";
 @import "components/tables";
 @import "components/snippets";
+@import "components/syntax";
 
 @import "layout/header";
 @import "layout/footer";
 
 @import "pages/home";
+@import "pages/blog";


### PR DESCRIPTION
I wrote a quick and dirty middleman site which is the currently blog at http://solidus.io/blog (related: I've disabled this project's build in jenkins).

When this site is ready, however, it would be nice to integrate the blog. I made this using middleman-blog, middleman-syntax, and minimal styles to make this look somewhat reasonable.

Preview:

![](http://i.hawth.ca/s/Jr4zDVhg.png)
