### PR TITLE
Make blog posts on index be equal height

### DIFF
--- a/source/blog/index.html.erb
+++ b/source/blog/index.html.erb
@@ -7,10 +7,8 @@ per_page: 10
   <div class="articles-list">
     <% page_articles.each_with_index do |article, i| %>
       <article class="article-list-item">
-        <div class="article-list-item-heading">
-          <h2 class="article-list-item-title"><%= link_to article.title, article %></h2>
-          <span class="article-list-item-meta"><%= article.date.strftime('%b %-d, %Y') %> • <%= article.data[:author] %></span>
-        </div>
+        <h2 class="article-list-item-title"><%= link_to article.title, article %></h2>
+        <span class="article-list-item-meta"><%= article.date.strftime('%b %-d, %Y') %> • <%= article.data[:author] %></span>
       </article>
     <% end %>
   </div>

--- a/source/stylesheets/pages/_blog.scss
+++ b/source/stylesheets/pages/_blog.scss
@@ -27,6 +27,8 @@ body.blog_index .main-content {
   margin: $gutter 0;
 
   @include breakpoint($desktop) {
+    @include display(flex);
+    @include flex-wrap(wrap);
     margin: $gutter (-$gutter/4);
     font-size: 0; // inline block hack
   }
@@ -34,20 +36,17 @@ body.blog_index .main-content {
 
 .article-list-item {
   margin-bottom: $gutter/2;
+  padding: 1em 3em;
   text-align: center;
+  border: 1px solid $color-grey;
 
   @include breakpoint($desktop) {
-    width: 50%;
+    @include calc(width, "50% - #{$gutter/2}");
     display: inline-block;
     vertical-align: top;
-    padding: 0 $gutter/4;
+    @include margin(null $gutter/4);
     font-size: $font-size-base;
   }
-}
-
-.article-list-item-heading {
-  padding: 1em 3em;
-  border: 1px solid $color-grey;
 }
 
 .article-list-item-title {


### PR DESCRIPTION
We're going to use flexbox here because it's awesome and we're making an
assumption that people reading this blog are developers that are using
modern web browsers.

We're able to remove the `.article-list-item-heading` div as it was only
being used to create the border effect which we can now just put on the
article itself.

Flexbox!
