### PR TITLE
Add basic hr-tag styling

### DIFF
--- a/source/stylesheets/components/_typography.scss
+++ b/source/stylesheets/components/_typography.scss
@@ -98,3 +98,9 @@ pre {
 code {
 
 }
+
+hr {
+  height: 1px;
+  background-color: $color-grey;
+  border: 0;
+}


### PR DESCRIPTION
Because the default browser HRs are quite ugly. We should style them to
appear as many of the borders do: a skinny, grey line.
