### PR TITLE
Separate home lead sections

### DIFF
--- a/source/partials/home/_lead.html.erb
+++ b/source/partials/home/_lead.html.erb
@@ -1,7 +1,9 @@
 <div class="home-section stretched darker lead">
-  <h2>Open Source eCommerce done right</h2>
+  <div class="lead-opening">
+    <h2>Open Source eCommerce done right</h2>
 
-  <p>Meet Solidus. An open source, eCommerce application for high volume retailers. Built with Ruby on Rails, this mountable engine provides a scalable, stable, and highly customizable platform for online commerce.</p>
+    <p>Meet Solidus. An open source, eCommerce application for high volume retailers. Built with Ruby on Rails, this mountable engine provides a scalable, stable, and highly customizable platform for online commerce.</p>
+  </div>
 
   <div class="api-features">
     <div class="grid-items">
@@ -22,5 +24,7 @@
     </div>
   </div>
 
-  <p><a class="button" href="/blog/2015/08/11/version-1-0-0.html">1.0.0 Release Notes</a></p>
+  <div class="get-started">
+    <a class="button button-huge" href="/blog/2015/08/11/version-1-0-0.html">1.0.0 Release Notes</a>
+  </div>
 </div>

--- a/source/stylesheets/components/_buttons.scss
+++ b/source/stylesheets/components/_buttons.scss
@@ -51,3 +51,8 @@
 .button-small {
   padding: 0.5em 1.2em;
 }
+
+.button-huge {
+  padding: 1em 2.5em;
+  font-size: 1em;
+}

--- a/source/stylesheets/pages/_home.scss
+++ b/source/stylesheets/pages/_home.scss
@@ -1,7 +1,3 @@
-.home-sections {
-
-}
-
 .home-section {
   border-top: 1px solid $color-grey;
   margin-top: 100px;

--- a/source/stylesheets/pages/home/_lead.scss
+++ b/source/stylesheets/pages/home/_lead.scss
@@ -1,26 +1,36 @@
 .home-section.lead {
   margin-top: 0;
+  padding: $gutter*2 0 0 0;
   text-align: center;
 
-  > h2,
-  > p {
-    max-width: 600px;
-    margin-left: auto;
-    margin-right: auto;
+  .lead-opening {
+    margin-bottom: $gutter*2;
 
-    &:first-child {
-      margin-top: 0;
-    }
+    h2,
+    p {
+      max-width: 600px;
+      margin-left: auto;
+      margin-right: auto;
 
-    &:last-child {
-      margin-bottom: 0;
+      &:first-child {
+        margin-top: 0;
+      }
+
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
   }
 }
 
 .api-features {
-  max-width: 900px;
-  margin: 0 auto $gutter;
+  padding: 0 0 $gutter/2 0;
+  background-color: darken($color-secondary, 4%);
+
+  .grid-items {
+    max-width: 900px;
+    margin: 0 auto $gutter;
+  }
 }
 
 .api-feature {
@@ -32,4 +42,9 @@
     display: block;
     margin: 0 auto $gutter/4;
   }
+}
+
+.get-started {
+  padding: $gutter/2 0;
+  background-color: darken($color-secondary, 8%);
 }


### PR DESCRIPTION
Gradually darken each section's background colour to better
differentiate which content is which and lead the eye towards the
call-to-action at the bottom.

![capture](https://cloud.githubusercontent.com/assets/270946/9206359/20dd38e0-401c-11e5-9d6b-5feeb47ec5a5.png)
