### PR TITLE
Fix typo on goals partial

### DIFF
--- a/source/partials/home/_goals.html.erb
+++ b/source/partials/home/_goals.html.erb
@@ -30,7 +30,7 @@
 
       <div class="project-plan">
         <p><strong>Take the Easy Path</strong></p>
-        <p>A clear and straightforward migration path has been created to move existing Spree stores onto the Solidus platform with ease. Read our <a href="https://github.com/solidusio/solidus/wiki/Versioning">Version guidelines</a> guidelines for details.</p>
+        <p>A clear and straightforward migration path has been created to move existing Spree stores onto the Solidus platform with ease. Read our <a href="https://github.com/solidusio/solidus/wiki/Versioning">versioning</a> guidelines for details.</p>
       </div>
 
       <div class="project-plan">


### PR DESCRIPTION
The word guidelines was duplicated. Updated link to remove duplicate
and lowercased.
