### PR TITLE
Update the versioning guidelines link on home page

### DIFF
--- a/source/partials/home/_goals.html.erb
+++ b/source/partials/home/_goals.html.erb
@@ -30,7 +30,7 @@
 
       <div class="project-plan">
         <p><strong>Take the Easy Path</strong></p>
-        <p>A clear and straightforward migration path has been created to move existing Spree stores onto the Solidus platform with ease. Read our <a href="https://github.com/solidusio/solidus/wiki/Versioning">versioning</a> guidelines for details.</p>
+        <p>A clear and straightforward migration path has been created to move existing Spree stores onto the Solidus platform with ease. Read our <a href="https://github.com/solidusio/solidus/wiki/Versioning-Guidelines">versioning guidelines</a> for details.</p>
       </div>
 
       <div class="project-plan">


### PR DESCRIPTION
Wiki was cleaned up leaving a broken link on the Solidus site to where it used to be
I also highlighted both words instead of just 'versioning'
![versioning guidelines](https://cloud.githubusercontent.com/assets/15271353/13686229/bd2f8b86-e6c9-11e5-9b87-4ba844324d1f.png)
