### PR TITLE
Add meta data to blog posts

### DIFF
--- a/data/people.yml
+++ b/data/people.yml
@@ -39,3 +39,14 @@
   github: https://github.com/mamhoff
   twitter_name: mamhoff
   core_contributor: true
+-
+  name: Amanda Healey
+  title: UX designer
+  github_name: Mandily
+-
+  name: Susan Aili
+  title: Manager of things
+  twitter_name: SusanAili
+-
+  name: Solidus core team
+  twitter_name: solidusio


### PR DESCRIPTION
I haven't validated this because I'm too lazy to setup an ssh tunnel but it's based on the Stembolt site and the tags _look_ legit.

I still wish we had a `full_url` helper (for both sites) so that we could add `og:url` and `og:image`
