### PR TITLE
Added link to FAQ in header

### DIFF
--- a/source/partials/_header.html.erb
+++ b/source/partials/_header.html.erb
@@ -6,6 +6,7 @@
 
     <ul>
       <li><%= link_to "Blog", "/blog" %></li>
+      <li><a href="https://github.com/solidusio/solidus/wiki/FAQ">FAQ</a></li>
       <li><a href="http://docs.solidus.io/">Documentation</a></li>
       <li><a href="https://github.com/solidusio/solidus">Github</a></li>
     </ul>


### PR DESCRIPTION
I didn’t know we had a FAQ until I asked John about making one.
I put a link in the header to make it more visible to others looking for answers.
