### PR TITLE
Update hostname for 2016 conference videos

### DIFF
--- a/source/partials/_solidus_conf_banner.html.erb
+++ b/source/partials/_solidus_conf_banner.html.erb
@@ -1,4 +1,4 @@
 <div class="alert solidus-conf-alert">
   Missed out on SolidusConf 2016? Watch the
-  <a href="http://conf.solidus.io/speaker_videos/">speaker videos</a>.
+  <a href="http://conf2016.solidus.io/speaker_videos/">speaker videos</a>.
 </div>


### PR DESCRIPTION
conf.solidus.io will soon redirect to conf2017.solidus.io