### PR TITLE
Swap out current references to Lost My Name

### DIFF
--- a/data/people.yml
+++ b/data/people.yml
@@ -1,6 +1,6 @@
 -
   name: Jordan Brough
-  title: Senior Software Developer, Lost My Name
+  title: Senior Software Developer, Wonderbly
   avatar: jordan.jpg
   github: https://github.com/jordan-brough
 -

--- a/source/partials/home/_people.html.erb
+++ b/source/partials/home/_people.html.erb
@@ -6,7 +6,7 @@
       <p>
         Solidus is backed and developed primarily by <a href="https://stembolt.com/">Stembolt</a>,
         <a href="https://nebulab.it/">Nebulab</a>, and
-        <a href="https://www.lostmy.name/">Lost My Name</a>. All three companies
+        <a href="https://www.wonderbly.com/">Wonderbly</a>. All three companies
         have leveraged the Solidus platform to build large ecommerce stores while
         contributing back to the open source project.
       </p>


### PR DESCRIPTION
I’m leaving references to the company throughout the SolidusConf 2017 text

Fixes #112