### PR TITLE
Omit blog images from asset hash

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -62,7 +62,7 @@ configure :build do
   activate :minify_javascript
 
   # Enable cache buster
-  activate :asset_hash
+  activate :asset_hash, ignore: [/^blog/]
 
   # Use relative URLs
   activate :relative_assets


### PR DESCRIPTION
Don't ask me why this works fine on my mac but not on Jenkins, it seems other people have this problem as well

https://github.com/middleman/middleman-blog/issues/167