### PR TITLE
Fix off centre mobile view

### DIFF
--- a/source/assets/stylesheets/components/_navigation.scss
+++ b/source/assets/stylesheets/components/_navigation.scss
@@ -41,6 +41,7 @@
     width: 48px;
     height: 48px;
     padding: 16px;
+    transform: translateX(12px);
 
     &, .isvg{
       display: block;

--- a/source/assets/stylesheets/vendor/bootstrap/theme/_grid.scss
+++ b/source/assets/stylesheets/vendor/bootstrap/theme/_grid.scss
@@ -5,7 +5,7 @@
 .container {
   @include media-breakpoint-down(sm){
     padding-left: 24px;
-    padding-right: 12px;
+    padding-right: 24px;
   }
 }
 


### PR DESCRIPTION
This bug was introduced when additional padding was added around the
menu toggle button (mobile). The extra padding moved the button 12px to
the left, which made the button look too far away from the edge of the
screen. The previous solution adjusted the padding around the
navbar to accomodate for this, but it also inadvertently changed the
padding for the entire layout. This new fix reverts that change and
appliess the 12px change directly to the menu element itself.