### PR TITLE
Fix image jumping

### DIFF
--- a/source/assets/stylesheets/components/_blocks.scss
+++ b/source/assets/stylesheets/components/_blocks.scss
@@ -171,3 +171,11 @@
     }
   }
 }
+
+.rings-tab {
+  height: 500px;
+}
+
+.decision-makers-tab {
+  height: 600px;
+}

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -56,7 +56,7 @@ title: Home
           </ul>
 
           <!-- Tab panes -->
-          <div class="tab-content">
+          <div class="tab-content decision-makers-tab">
             <div class="tab-pane active fade show" id="block1t1" role="tabpanel">
               <h2 class="title">The only store framework you’ll ever need.</h2>
               <p>Hosted ecommerce solutions are a great option for simple stores with low to medium traffic. But what happens when your store’s needs outgrow the capabilities of your current solution? Solidus was built to support high-volume stores with varied and complex needs. Many outlying use cases or specific features have already been included in our platform. </p>
@@ -118,7 +118,7 @@ title: Home
             </li>
           </ul>
 
-          <div class="tab-content">
+          <div class="tab-content rings-tab">
             <div class="tab-pane active fade show" id="block2t1" role="tabpanel">
               <h2 class="title">Don’t reinvent the wheel.</h2>
               <p>Are you sinking big bucks into your own in-house ecommerce solution as your developers struggle to keep up with features requests? Solidus keeps your store running smoothly, while a community of developers work together around the world to improve the platform. </p>


### PR DESCRIPTION
When switching tabs in the two tab panes on the homepage, the image
would move around. This was caused by the text in one column
growing/shrinking, which then changed the size of the div, resulting in
the image needing to be centered again. To fix this, a fixed height
value has been set.

This PR resolves #128 