### PR TITLE
Fix mobile menu not filling screen

### DIFF
--- a/source/assets/stylesheets/components/_navigation.scss
+++ b/source/assets/stylesheets/components/_navigation.scss
@@ -82,7 +82,7 @@
   position: fixed;
   right: 0;
   text-align: center;
-  height: calc(100vh - #{$mobile-header-height});
+  height: calc(100vh - #{$mobile-header-height} + 1px); // 1px represents the bottom-border on the header
   z-index: $zindex-sticky;
 
   .menu-items{


### PR DESCRIPTION
When the calculation is done to determine the size of the menu fill on
mobile, the border underneath the header was not taken into account.
This commit remedies this, by taking the extra 1px into account when
determining the height of the menu background.

Visually, this appeared as the page underneath the menu showing through the bottom portion of the menu. This opening was only about 1px large, but was still noticeable.