### PR TITLE
Fix image overlap on mobile

### DIFF
--- a/source/assets/stylesheets/components/_blocks.scss
+++ b/source/assets/stylesheets/components/_blocks.scss
@@ -173,9 +173,9 @@
 }
 
 .rings-tab {
-  height: 500px;
+  @include media-breakpoint-up(md) { height: 500px; }
 }
 
 .decision-makers-tab {
-  height: 600px;
+  @include media-breakpoint-up(md) { height: 600px; }
 }


### PR DESCRIPTION
Images on the tab pane on the home page were overlapping with some text when in the single column view on small displays. This was caused by a fixed height being set on some text. To remedy this, we only set a fixed height when we are in the two column view (larger screens).