### PR TITLE
Fix missing footer on mobile

### DIFF
--- a/source/assets/stylesheets/components/_layout.scss
+++ b/source/assets/stylesheets/components/_layout.scss
@@ -78,7 +78,7 @@ body{
   .isvg-coffee-love{ margin-bottom: 0.5rem; }
 
   @include media-breakpoint-down(md){
-    display: none;
+    .site_footer { display: none; }
   }
 
   @include media-breakpoint-up(lg) {


### PR DESCRIPTION
The footer was accidentally removed altogether from mobile in a previous commit.