### PR TITLE
Remove Solidus Paperclip extension link

### DIFF
--- a/source/extensions.html.erb
+++ b/source/extensions.html.erb
@@ -91,16 +91,6 @@ layout: extensions
               </div>
             </div>
 
-
-            <div class="extension-info card card-border-none e-admin">
-              <div class="card-body">
-                <h4 class="title">Solidus paperclip</h4>
-                <div class="categories"><span class="category">Admin</span></div>
-                <p>Upload and attach images to products, variants and taxons.</p>
-                <a class="link" href="https://github.com/StemboltHQ/paperclip" target="_blank">Get it on GitHub</a>
-              </div>
-            </div>
-
             <div class="extension-info card card-border-none e-admin">
               <div class="card-body">
                 <h4 class="title">Solidus product assembly</h4>


### PR DESCRIPTION
Solidus Paperclip is not an extension (yet). It is still integrated into Solidus core.

This PR fixes #147 