### PR TITLE
Don't use directory indexes for blog posts

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -33,6 +33,7 @@ activate :blog do |blog|
 end
 
 activate :directory_indexes
+page 'blog/*', :directory_index => false
 
 activate :external_pipeline,
          name: :webpack,


### PR DESCRIPTION
As the old Solidus site did not use directory indexing, the links for the old site are now dead. With this change, the format for blog post URLs will be in line with what they were previously, which will preserve any links that are floating around out there.