### PR TITLE
Add cache invalidation

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -49,6 +49,10 @@ activate :s3_sync do |s3_sync|
   s3_sync.aws_secret_access_key = ENV["AWS_SECRET"]
 end
 
+default_caching_policy max_age: (60 * 60 * 24 * 365)
+caching_policy "text/html", max_age: 0, must_revalidate: true
+caching_policy "application/xml", max_age: 0, must_revalidate: true
+
 configure :development do
   config[:contact_url] = "http://localhost:4567/contact"
 end


### PR DESCRIPTION
This change ensures that we're always serving new content. This is especially important due to the fact that we hash our assets. Without this change, we will be attempting to serve content that no longer exists every time we deploy a new build.

These lines of code are taken from the [Stembolt site](https://github.com/StemboltHQ/stembolt-site/blob/85c262fe7d1a419070a338f549a86d9d3c546cb6/config.rb#L147-L149).

Thanks to @Sinetheta for pointing me in the right direction (telling me exactly what to do).