### PR TITLE
Remove height attribute from commit list

### DIFF
--- a/source/assets/stylesheets/components/_blocks.scss
+++ b/source/assets/stylesheets/components/_blocks.scss
@@ -182,7 +182,6 @@
 
 .github {
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  height: 624px;
 }
 
 // Override reboot.scss


### PR DESCRIPTION
This height attribute was forcing the GitHub commit list to a fixed height, which caused the commits to overflow their container when the commit messages were expanded.