### PR TITLE
Fix margin around p elements

### DIFF
--- a/source/assets/stylesheets/components/_blocks.scss
+++ b/source/assets/stylesheets/components/_blocks.scss
@@ -213,7 +213,7 @@
   border: 1px solid #e1e4e8;
 }
 
-.github ol, p {
+.github ol, .github p {
   padding: 0;
   margin: 0;
 }


### PR DESCRIPTION
On the GitHub commits element, p elements are meant to have 0 margin and padding. However, the styles used unintentionally applied 0 margin and padding to all p elements on the site.

Thanks @seantaylor for pointing this out.