### PR TITLE
Fix GitHub commit title parsing error

### DIFF
--- a/source/assets/javascripts/github.js
+++ b/source/assets/javascripts/github.js
@@ -65,7 +65,7 @@ function setAuthorElements(commit, commit_json) {
 }
 
 function setTitle(commit, commit_json) {
-  if (commit_json['committer']['login'] === 'web-flow') {
+  if ((commit_json['committer']['login'] === 'web-flow') && commit_json['commit']['message'].startsWith('Merge')) {
     setWebFlowTitle(commit, commit_json);
     commit.querySelector('.user-commit').remove();
   } else {


### PR DESCRIPTION
When parsing the response from GitHub, I made the assumption that a
commit with the author of 'webflow' would always be a merge commit; this
is not the case.

To fix this, I've added an extra check to make sure that the commit
message is actually a merge commit by checking that the commit message
starts with 'Merge'.

Here's an example of the issue this was causing (we should be seeing 10 commits):

![screenshot from 2018-05-23 12-26-27](https://user-images.githubusercontent.com/10660608/40446647-c77ca602-5e84-11e8-92d1-cc90a06d39a1.png)
