### PR TITLE
Add basic table styles to blog posts

### DIFF
--- a/source/assets/stylesheets/components/_blog.scss
+++ b/source/assets/stylesheets/components/_blog.scss
@@ -84,4 +84,9 @@
     margin: 0 auto;
     display: block;
   }
+
+  table {
+    width: 100%;
+    margin: 1rem 0;
+  }
 }


### PR DESCRIPTION
Tables in blog posts previously had no styles applied to them and as a
result looked quite squished. This commit adds some basic styles so that
tables take up the whole width and have a bit of top/bottom margin.

These styles don't look amazing on mobile, but it's a step up from what
we had previously, which looked obviously broken. In the future, we
could consider using the mobile table styles from the Solidus docs site.

This closes #153 

**Before**
![before_table](https://user-images.githubusercontent.com/10660608/40450265-fcb37084-5e8f-11e8-8205-27562b9fc663.png)

**After**
![after_table_solidus](https://user-images.githubusercontent.com/10660608/40450270-0277bce6-5e90-11e8-9d15-74688f7bc9e8.png)

