### PR TITLE
Make page titles SEO-friendly

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -8,6 +8,8 @@ set :images_dir, "assets/images"
 set :js_dir, "assets/javascripts"
 set :base_url, build? ? "https://solidus.io" : "http://localhost:4567"
 
+set :seo_title, "Solidus: Rails Ecommerce Platform"
+
 activate :blog do |blog|
   blog.layout = 'blog'
   blog.prefix = 'blog'

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,5 +1,4 @@
 ---
-title: Home
 ---
 
 <div class="content-block content-block-lg content-block-gray-900">

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -9,7 +9,12 @@
   <link rel="apple-touch-icon" href='/assets/images/favicon/apple-touch-icon.png'>
   <link rel="shortcut icon" type="image/x-icon" href='/assets/images/favicon/favicon.ico'>
 
-  <title><%= current_page.data.title || "Middleman" %></title>
+  <title>
+    <% if current_page.data.title %>
+      <%= current_page.data.title + " | " %>
+    <% end %>
+    <%= config[:seo_title] %>
+  </title>
 
   <%= javascript_include_tag "modernizr" %>
   <%= stylesheet_link_tag "site" %>


### PR DESCRIPTION
Previously, `<title>` tags did not reference Solidus or what it is at all. Because search engine results include the `<title>` tag this is bad for SEO.

This commit fixes #157.