### PR TITLE
Update core team link in footer

### DIFF
--- a/source/partials/_footer.erb
+++ b/source/partials/_footer.erb
@@ -20,7 +20,7 @@
         </nav>
 
         <div class="text-white-048">
-          Maintained by the <a class="text-white" href="/developers#core-team">core team</a> with the help of our <a class="text-white" href="https://github.com/solidusio/solidus/graphs/contributors" target="_blank">our contributors</a>, directed by <a class="text-white" href="https://nebulab.it/" target="_blank">Nebulab</a>.
+          Maintained by the <a class="text-white" href="/community#core-team">core team</a> with the help of our <a class="text-white" href="https://github.com/solidusio/solidus/graphs/contributors" target="_blank">our contributors</a>, directed by <a class="text-white" href="https://nebulab.it/" target="_blank">Nebulab</a>.
         </div>
       </div>
       <div class="col-lg-5">


### PR DESCRIPTION
This probably could be added to #194, but as that's already been reviewed it can be done here.