### PR TITLE
Make sections in /extensions linkable

### DIFF
--- a/source/extensions.html.erb
+++ b/source/extensions.html.erb
@@ -50,7 +50,7 @@ title: Extensions
     </div>
 
     <div class="accordion">
-      <div class="extensions-group accordion-item">
+      <div class="extensions-group accordion-item" id="search">
         <h3 class="title"><a class="" href="#" data-toggle="collapse" data-target="#collapse1">Search <%= inline_svg("icons/arrow-down.svg", class: "isvg isvg-arrow") %></a></h3>
 
         <div id="collapse1" class="content collapse show" data-parent="#accordion">
@@ -67,7 +67,7 @@ title: Extensions
         </div>
       </div>
 
-      <div class="extensions-group accordion-item">
+      <div class="extensions-group accordion-item" id="products-and-invetory">
         <h3 class="title"><a class="collapsed" href="#" data-toggle="collapse" data-target="#collapse2">Products & Inventory <%= inline_svg("icons/arrow-down.svg", class: "isvg isvg-arrow") %></a></h3>
 
         <div id="collapse2" class="content collapse" data-parent="#accordion">
@@ -120,7 +120,7 @@ title: Extensions
         </div>
       </div>
 
-      <div class="extensions-group accordion-item">
+      <div class="extensions-group accordion-item" id="orders">
         <h3 class="title"><a class="collapsed" href="#" data-toggle="collapse" data-target="#collapse3">Orders <%= inline_svg("icons/arrow-down.svg", class: "isvg isvg-arrow") %></a></h3>
 
         <div id="collapse3" class="content collapse" data-parent="#accordion">
@@ -159,7 +159,7 @@ title: Extensions
         </div>
       </div>
 
-      <div class="extensions-group accordion-item">
+      <div class="extensions-group accordion-item" id="sales">
         <h3 class="title"><a class="collapsed" href="#" data-toggle="collapse" data-target="#collapse4">Sales <%= inline_svg("icons/arrow-down.svg", class: "isvg isvg-arrow") %></a></h3>
 
         <div id="collapse4" class="content collapse" data-parent="#accordion">
@@ -213,7 +213,7 @@ title: Extensions
         </div>
       </div>
 
-      <div class="extensions-group accordion-item">
+      <div class="extensions-group accordion-item" id="payments">
         <h3 class="title"><a class="collapsed" href="#" data-toggle="collapse" data-target="#collapse5">Payments <%= inline_svg("icons/arrow-down.svg", class: "isvg isvg-arrow") %></a></h3>
 
         <div id="collapse5" class="content collapse" data-parent="#accordion">
@@ -310,7 +310,7 @@ title: Extensions
       </div>
 
 
-      <div class="extensions-group accordion-item">
+      <div class="extensions-group accordion-item" id="shipping">
         <h3 class="title"><a class="collapsed" href="#" data-toggle="collapse" data-target="#collapse6">Shipping <%= inline_svg("icons/arrow-down.svg", class: "isvg isvg-arrow") %></a></h3>
 
         <div id="collapse6" class="content collapse" data-parent="#accordion">
@@ -354,7 +354,7 @@ title: Extensions
         </div>
       </div>
 
-      <div class="extensions-group accordion-item">
+      <div class="extensions-group accordion-item" id="social">
         <h3 class="title"><a class="collapsed" href="#" data-toggle="collapse" data-target="#collapseSocial">Social <%= inline_svg("icons/arrow-down.svg", class: "isvg isvg-arrow") %></a></h3>
 
         <div id="collapseSocial" class="content collapse" data-parent="#accordion">
@@ -384,7 +384,7 @@ title: Extensions
         </div>
       </div>
 
-      <div class="extensions-group accordion-item">
+      <div class="extensions-group accordion-item" id="seo-and-tracking">
         <h3 class="title"><a class="collapsed" href="#" data-toggle="collapse" data-target="#collapseSEO">SEO & Tracking <%= inline_svg("icons/arrow-down.svg", class: "isvg isvg-arrow") %></a></h3>
 
         <div id="collapseSEO" class="content collapse" data-parent="#accordion">
@@ -425,7 +425,7 @@ title: Extensions
         </div>
       </div>
 
-      <div class="extensions-group accordion-item">
+      <div class="extensions-group accordion-item" id="authoring">
         <h3 class="title"><a class="collapsed" href="#" data-toggle="collapse" data-target="#collapseAuthoring">Authoring <%= inline_svg("icons/arrow-down.svg", class: "isvg isvg-arrow") %></a></h3>
 
         <div id="collapseAuthoring" class="content collapse" data-parent="#accordion">
@@ -455,7 +455,7 @@ title: Extensions
         </div>
       </div>
 
-      <div class="extensions-group accordion-item">
+      <div class="extensions-group accordion-item" id="tools">
         <h3 class="title"><a class="collapsed" href="#" data-toggle="collapse" data-target="#collapseTools">Tools <%= inline_svg("icons/arrow-down.svg", class: "isvg isvg-arrow") %></a></h3>
 
         <div id="collapseTools" class="content collapse" data-parent="#accordion">
@@ -496,7 +496,7 @@ title: Extensions
         </div>
       </div>
 
-      <div class="extensions-group accordion-item">
+      <div class="extensions-group accordion-item" id="customers-and-users">
         <h3 class="title"><a class="collapsed" href="#" data-toggle="collapse" data-target="#collapseCustomers">Customers & Users <%= inline_svg("icons/arrow-down.svg", class: "isvg isvg-arrow") %></a></h3>
 
         <div id="collapseCustomers" class="content collapse" data-parent="#accordion">
@@ -527,7 +527,7 @@ title: Extensions
         </div>
       </div>
 
-      <div class="extensions-group accordion-item">
+      <div class="extensions-group accordion-item" id="i18n">
         <h3 class="title"><a class="collapsed" href="#" data-toggle="collapse" data-target="#collapseInternationalization">Internationalization <%= inline_svg("icons/arrow-down.svg", class: "isvg isvg-arrow") %></a></h4>
 
         <div id="collapseInternationalization" class="content collapse" data-parent="#accordion">


### PR DESCRIPTION
Although it's still required to go into the HTML to get the correct anchor, this allows at 
least to the pro user to build links to specific sections.

E.g. https://solidus.io/extensions/#payments