### PR TITLE
Add a dev picture to the Community hero animation

### DIFF
--- a/source/assets/stylesheets/components/_community.scss
+++ b/source/assets/stylesheets/components/_community.scss
@@ -144,7 +144,13 @@
   .dev-2{
     @include img-retina("/assets/images/team/thomas-von-deyen.png", "/assets/images/team/thomas-von-deyen@2x.png", 100%, auto);
     background-color: $white;
-    animation: devFade 10s ease-in-out 1s infinite alternate;
+    animation: devFade 12s ease-in-out 2s infinite alternate;
+  }
+  
+  .dev-3{
+    @include img-retina("/assets/images/team/andrea-longhi.png", "/assets/images/team/andrea-longhi@2x.png", 100%, auto);
+    background-color: $white;
+    animation: devFade3slide 12s ease-in-out 2s infinite alternate;
   }
 }
 
@@ -210,6 +216,24 @@
   }
   55% {
   opacity:0;
+  }
+  100% {
+  opacity:0;
+  }
+}
+
+@keyframes devFade3slide {
+  0% {
+  opacity:1;
+  }
+  35% {
+  opacity:0;
+  }
+  50% {
+  opacity:1;
+  }
+  75% {
+    opacity:0;
   }
   100% {
   opacity:0;

--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -52,6 +52,7 @@ title: Community
       <div class="dev-slide wrapper-3">
         <div class="dev-circle dev-1"></div>
         <div class="dev-circle dev-2"></div>
+        <div class="dev-circle dev-3"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Ref. #199 

The last core has been added also inside the Community hero, as the other members were. All the devs pictures rotate with a CSS animation.

<img width="1313" alt="Schermata 2019-07-02 alle 15 18 42" src="https://user-images.githubusercontent.com/46188345/60516436-0dd13d00-9cde-11e9-8c95-df629348bb0e.png">
