### PR TITLE
Adding Solidus Conf blog post

### DIFF
--- a/source/blog/2019-07-17-solidus-conf-2019.html.markdown
+++ b/source/blog/2019-07-17-solidus-conf-2019.html.markdown
@@ -40,7 +40,7 @@ Have an awesome idea for a talk you want to give at SolidusConf? Our CFP is now 
 
 ### Tickets
 
-Tickets are available through [OpenCollective](https://opencollective.com/solidus/events/solidusconf-2019-21928ev). If you're unable to purchase a ticket, give us a shout at info@southeastsolid.us - we want you to be able to attend!
+Tickets are available through [OpenCollective](https://opencollective.com/solidus/events/solidusconf-2019-21928ev). If you are unable to attend because of the price, give us a shout at info@southeastsolid.us - we want everyone to be able to attend!
 
 ### Updates
 


### PR DESCRIPTION
*This is now complete - should be ready to merge!*

Hey all! Here's a sample blog post for SolidusConf. If this is acceptable, it can also double as the OpenCollective copy for the event with some slight modification. OpenCollective does allow markup, so it should work and look just fine. 

Two things that still need to be done:

- [x] Add E-Mail contact for cheaper/free tickets for whoever needs them
- [x] Add OpenCollective event link (when it's up)

Let me know what you guys think - I'm happy to make any modifications, or feel free to edit them here as you see fit.

Thanks!