### PR TITLE
Add Quora Pixel Code

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -29,6 +29,14 @@
     ga('send', 'pageview');
     ga('TemporaryAccount.send', 'pageview');
   </script>
+  <!-- Quora Pixel Code (JS Helper) -->
+  <script>
+    !function(q,e,v,n,t,s){if(q.qp) return; n=q.qp=function(){n.qp?n.qp.apply(n,arguments):n.queue.push(arguments);}; n.queue=[];t=document.createElement(e);t.async=!0;t.src=v; s=document.getElementsByTagName(e)[0]; s.parentNode.insertBefore(t,s);}(window, 'script', '<https://a.quora.com/qevents.js');>
+    qp('init', 'cd9c03928efb4d6290b2a522597fe938');
+    qp('track', 'ViewContent');
+  </script>
+  <noscript><img height="1" width="1" style="display:none" src="<https://q.quora.com/_/ad/cd9c03928efb4d6290b2a522597fe938/pixel?tag=ViewContent&noscript=1"/></noscript>
+  <!-- End of Quora Pixel Code -->
 </head>
 
 <body>


### PR DESCRIPTION
This PR adds the Quora Pixel Code snippet to the `<head>` of the website.

We're testing [Quora Ads](https://www.quora.com/business) effectiveness to promote Solidus and increase brand awareness, and we need to install the Quora pixel to optimize campaigns performance by leveraging website audience for Retargeting and Lookalike Targeting.