### PR TITLE
Add Community guidelines to the website

### DIFF
--- a/source/assets/stylesheets/components/_blocks.scss
+++ b/source/assets/stylesheets/components/_blocks.scss
@@ -70,6 +70,11 @@
   margin: 0 auto;
 }
 
+// Community guidelines page wrapper
+.community-guidelines-block {
+  max-width: 680px;
+  margin: 0 auto;
+}
 
 //Features hero banner
 .features-hero{

--- a/source/community-guidelines.html.erb
+++ b/source/community-guidelines.html.erb
@@ -1,0 +1,327 @@
+---
+title: Community guidelines
+---
+
+<div class="content-block container">
+  <div class="community-guidelines-block">
+    <h1 id="community-guidelines" class="title">Community guidelines</h1>
+
+    <div class="mb-4 mb-md-6">
+      <p>
+        Like the technical community as a whole, the Solidus team and community is made up of a
+        mixture of professionals and volunteers from all over the world, working on every aspect of
+        the product.
+      </p>
+
+      <p>
+        Interactions in a large community such as Solidus' can sometimes lead to communication
+        issues. To that end, we have a few ground rules that we ask people to adhere to. These
+        guidelines apply equally to individuals in the following groups: sponsors, the Solidus
+        stakeholders, the Solidus core team and the Solidus community.
+      </p>
+
+      <p>
+        This isn't an exhaustive list of things that you should or shouldn't do. Rather, take it in
+        the spirit in which it's intended - a guide to make it easier to enrich all of us and the
+        technical communities in which we participate.
+      </p>
+
+      <p>
+        These guidelines apply to all official Solidus spaces. This includes Slack, the Solidus
+        GitHub organizations and any other online forums created by the project team which the
+        community uses for communication.
+      </p>
+
+      <p>
+        We don't cover spaces outside of those officially managed by the Solidus team, such as
+        Twitter, LinkedIn, unofficial Slack communities etc. This is intentional and it strikes a
+        balance that allows us to be inclusive of all ideas and viewpoints while also creating a
+        safe space for our community to collaborate.
+      </p>
+
+      <p>
+        If you believe someone is violating the guidelines, we ask that you report it by emailing
+        <a href="mailto:community@soliduscommerce.io">community@soliduscommerce.io</a>. For more
+        details please see our <a href="#reporting-guidelines">Reporting Guidelines</a>.
+      </p>
+
+      <ul>
+        <li><strong>Be friendly and patient.</strong></li>
+        <li>
+          <strong>Be welcoming.</strong> We strive to be a community that welcomes and supports
+          everyone. We intentionally refrain from making a list here, as we believe it would be
+          superfluous: no matter your identity, you are welcome to contribute to Solidus and
+          participate in its community.
+        </li>
+        <li>
+          <strong>Be considerate.</strong> Your work will be used by other people, and you in turn
+          will depend on the work of others. Any decision you take will affect users and colleagues,
+          and you should take those consequences into account when making decisions. Remember that
+          we're a world-wide community, so you might not be communicating in someone else's primary
+          language.
+        </li>
+        <li>
+          <strong>Be respectful.</strong> Not all of us will agree all the time, but disagreement is
+          no excuse for poor behavior and poor manners. We might all experience some frustration now
+          and then, but we cannot allow that frustration to turn into a personal attack. Members of
+          the Solidus community should be respectful when dealing with other members.
+        </li>
+        <li>
+          <strong>Be careful in the words that you choose.</strong> We are a community of
+          professionals, and we conduct ourselves professionally. Be kind to others. Do not insult
+          or put down other participants. Harassment and other exclusionary behavior aren't
+          acceptable. This is a comprehensive list of unacceptable behaviors:
+
+          <ul>
+            <li>Violent threats or language directed against another person.</li>
+            <li>
+              Discriminatory jokes and language (i.e. insulting or belittling someone for their
+              identity).
+            </li>
+            <li>Posting sexually explicit or violent material.</li>
+            <li>
+              Posting (or threatening to post) other people's personally identifying information
+              ("doxing").
+            </li>
+            <li>Personal insults.</li>
+            <li>Unwelcome sexual attention.</li>
+            <li>Advocating for, or encouraging, any of the above behavior.</li>
+          </ul>
+        </li>
+        <li>
+          <strong>When we disagree, try to understand why.</strong> Disagreements, both social and
+          technical, happen all the time and Solidus is no exception. It is important that we
+          resolve disagreements and differing views constructively. Remember that we're different.
+          Different people have different perspectives on issues. Being unable to understand why
+          someone holds a viewpoint doesn't mean that they're wrong, just like having someone
+          disagreeing with you doesn't mean they don't understand your viewpoint. Don't forget that
+          it is human to err and blaming each other doesn't get us anywhere. Instead, focus on
+          helping to resolve issues and learning from mistakes.
+        </li>
+      </ul>
+
+      <p>
+        Original text courtesy of the <a href="https://www.djangoproject.com/conduct/">Django Code
+        of Conduct</a> and the
+        <a href="http://web.archive.org/web/20141109123859/http://speakup.io/coc.html">Speak Up!
+        project</a>.
+      </p>
+
+      <h2 id="reporting-guidelines">Reporting Guidelines</h2>
+
+      <p>
+        If you believe someone is violating the guidelines we ask that you report it to the Solidus
+        team by emailing
+        <a href="mailto:community@soliduscommerce.io">community@soliduscommerce.io</a>.
+        <strong>All reports will be kept confidential.</strong> In some cases, we may determine that
+        a public statement will need to be made. If that's the case, the identities of all victims
+        and reporters will remain confidential unless those individuals instruct us otherwise.
+      </p>
+
+      <p>
+        <strong>If you believe anyone is in physical danger, please notify appropriate law
+          enforcement first.</strong> If you are unsure what law enforcement agency is appropriate,
+        please include this in your report and we will attempt to notify them.
+      </p>
+
+      <p>
+        If you are unsure whether the incident is a violation, or whether the space where it
+        happened is covered by these guidelines, we encourage you to still report it. We would much
+        rather have a few extra reports where we decide to take no action, rather than miss a report
+        of an actual violation. We do not look negatively on you if we find the incident is not a
+        violation. And knowing about incidents that are not violations can help us to improve the
+        guidelines or the processes surrounding them.
+      </p>
+
+      <p>In your report please include:</p>
+
+      <ul>
+        <li>Your contact info (so we can get in touch with you if we need to follow up)</li>
+        <li>
+          Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other
+          witnesses besides you, please try to include them as well.
+        </li>
+        <li>When and where the incident occurred. Please be as specific as possible.</li>
+        <li>
+          Your account of what occurred. If there is a publicly available record (e.g. Slack
+          messages) please include a link.
+        </li>
+        <li>Any extra context you believe existed for the incident.</li>
+        <li>If you believe this incident is ongoing.</li>
+        <li>Any other information you believe we should have.</li>
+      </ul>
+
+      <p>
+        We will review and act on all reports to the best of our abilities, but we will not be able
+        to act on reports when we are not able to collect objective information and/or witnesses
+        that can help us clarify the incident and individuals involved.
+      </p>
+
+      <h3 id="what-happens-after-you-file-a-report">What happens after you file a report?</h3>
+
+      <p>
+        You will receive an email from the Solidus Community Committee acknowledging receipt
+        immediately. We promise to acknowledge receipt within 5 business days (and will aim for much
+        quicker than that).
+      </p>
+
+      <p>The working group will immediately meet to review the incident and determine:</p>
+
+      <ul>
+        <li>What happened, making sure to also ask the reported person(s).</li>
+        <li>Whether this event constitutes a guidelines violation.</li>
+        <li>Who the bad actor was.</li>
+        <li>
+          Whether this is an ongoing situation, or if there is a threat to anyone's physical safety.
+        </li>
+      </ul>
+
+      <p>
+        If this is determined to be an ongoing incident or a threat to physical safety, the working
+        groups' immediate priority will be to protect everyone involved. This means we may delay an
+        "official" response until we believe that the situation has ended and that everyone is
+        physically safe.
+      </p>
+
+      <p>
+        Once the working group has a complete account of the events and all involved parties have
+        been heard, they will make a decision as to how to respond. Responses may include:
+      </p>
+
+      <ul>
+        <li>Nothing (if we determine no violation occurred).</li>
+        <li>A private or public reprimand from the committee to the individual(s) involved.</li>
+        <li>A permanent or temporary ban from some or all Solidus spaces.</li>
+      </ul>
+
+      <p>
+        We'll respond within one week to the person who filed the report with either a resolution or
+        an explanation of why the situation is not yet resolved.
+      </p>
+
+      <p>
+        Once we've determined our final action, we'll contact the original reporter to let them know
+        what action (if any) we'll be taking. We'll take into account feedback from the reporter on
+        the appropriateness of our response, but we don't guarantee we'll act on it.
+      </p>
+
+      <p>What if your report concerns a possible violation by a committee member?</p>
+
+      <p>
+        If your report concerns a current member of the Community Committee, you may not feel
+        comfortable sending your report to the committee, as all members will see the report.
+      </p>
+
+      <p>
+        In that case, you can make a report directly to any or all of the current chairs of the
+        Community Committee. Their e-mail addresses are listed on the Community Committee page.
+        The chairs will follow the usual enforcement process with the other members, but will
+        exclude the member(s) that the report concerns from any discussion or decision making.
+      </p>
+
+      <h2 id="enforcement-manual">Enforcement Manual</h2>
+
+      <h3 id="the-community-committee">The Community Committee</h3>
+
+      <p>
+        All responses to reports of conduct violations will be managed by a Community Committee
+        ("the committee").
+      </p>
+
+      <p>
+        The Solidus stakeholders ("the stakeholders") will propose this committee, comprised of at
+        least three members from the Solidus community. The stakeholders will review membership on a
+        regular basis. The committee and any changes to the committee must be approved by the core
+        team.
+      </p>
+
+      <h3 id="how-the-committee-will-respond-to-reports">
+        How the committee will respond to reports
+      </h3>
+
+      <p>
+        When a report is sent to the committee they will immediately reply to the report to confirm
+        receipt. This reply must be sent within 5 days, and the committee should strive to respond
+        much more quickly than that.
+      </p>
+
+      <p>
+        See the <a href="#reporting-guidelines">Reporting Guidelines</a> for details of what reports
+        should contain. If a report doesn't contain enough information, the committee will obtain
+        all relevant data before acting.
+      </p>
+
+      <p>
+        The committee will then review the incident and determine, to the best of their ability:
+      </p>
+
+      <ul>
+        <li>what happened;</li>
+        <li>whether this event constitutes a guidelines violation;</li>
+        <li>who, if anyone, was the bad actor;</li>
+        <li>
+          whether this is an ongoing situation, and there is a threat to anyone's physical safety.
+        </li>
+      </ul>
+
+      <p>
+        This information will be collected in writing, and whenever possible the committee's
+        deliberations will be recorded and retained (i.e. Slack transcripts, email discussions,
+        recorded voice conversations, etc).
+      </p>
+
+      <p>
+        The committee should aim to have a resolution agreed upon within one week. In the event that
+        a resolution can't be determined in that time, the committee will respond to the reporter(s)
+        with an update and projected timeline for resolution.
+      </p>
+
+      <h3 id="acting-unilaterally">Acting unilaterally</h3>
+
+      <p>
+        If the act involves a threat to anyone's physical safety (e.g. threats of violence), any
+        committee member may act unilaterally (before reaching consensus) to end the situation by
+        contacting the appropriate law enforcement authorities.
+      </p>
+
+      <p>
+        In situations where an individual committee member acts unilaterally, they must report their
+        actions to the committee for review within 24 hours.
+      </p>
+
+      <h3 id="resolutions">Resolutions</h3>
+
+      <p>
+        The committee must agree on a resolution by consensus. If the committee cannot reach
+        consensus and deadlocks for over a week, the committee will turn the matter over to the
+        stakeholders for resolution.
+      </p>
+
+      <p>Possible responses may include:</p>
+
+      <ul>
+        <li>Taking no further action (if we determine no violation occurred).</li>
+        <li>A private or public reprimand from the committee to the individual(s) involved.</li>
+        <li>
+          A permanent or temporary ban from some or all Solidus spaces. The committee will maintain
+          records of all such bans so that they may be reviewed in the future, extended to new
+          Solidus forums, or otherwise maintained.
+        </li>
+      </ul>
+
+      <p>
+        Once a resolution is agreed upon, the committee will contact the original reporter and any
+        other affected parties and explain the resolution.
+      </p>
+
+      <h3 id="conflicts-of-interest">Conflicts of Interest</h3>
+
+      <p>
+        If a report concerns a possible violation by a current committee member, this member should
+        be excluded from the response process. For these cases, anyone can make a report directly to
+        any of the committee chairs, as documented in the <a href="#reporting-guidelines">Reporting
+        Guidelines</a>.
+      </p>
+    </div>
+  </div>
+</div>

--- a/source/partials/_footer.erb
+++ b/source/partials/_footer.erb
@@ -19,6 +19,9 @@
             <li class="list-inline-item">
               <a class="text-white" href="/contact">Contact</a>
             </li>
+            <li class="list-inline-item">
+              <a class="text-white" href="/community-guidelines">Community guidelines</a>
+            </li>
           </ul>
         </nav>
 


### PR DESCRIPTION
Note that the community@solidus.io email doesn't currently exist. Not sure how we want to handle that, because we don't have access to the domain at the moment.