### PR TITLE
Adjust wording and formatting in community guidelines

### DIFF
--- a/source/community-guidelines.html.erb
+++ b/source/community-guidelines.html.erb
@@ -28,7 +28,7 @@ title: Community guidelines
 
       <p>
         These guidelines apply to all official Solidus spaces. This includes Slack, the Solidus
-        GitHub organizations and any other online forums created by the project team which the
+        GitHub organizations and any other online forums created by the core team which the
         community uses for communication.
       </p>
 
@@ -165,7 +165,7 @@ title: Community guidelines
         quicker than that).
       </p>
 
-      <p>The working group will immediately meet to review the incident and determine:</p>
+      <p>The committee will immediately meet to review the incident and determine:</p>
 
       <ul>
         <li>What happened, making sure to also ask the reported person(s).</li>
@@ -177,14 +177,14 @@ title: Community guidelines
       </ul>
 
       <p>
-        If this is determined to be an ongoing incident or a threat to physical safety, the working
-        groups' immediate priority will be to protect everyone involved. This means we may delay an
-        "official" response until we believe that the situation has ended and that everyone is
+        If this is determined to be an ongoing incident or a threat to physical safety, the
+        committee's immediate priority will be to protect everyone involved. This means we may delay
+        an "official" response until we believe that the situation has ended and that everyone is
         physically safe.
       </p>
 
       <p>
-        Once the working group has a complete account of the events and all involved parties have
+        Once the committee has a complete account of the events and all involved parties have
         been heard, they will make a decision as to how to respond. Responses may include:
       </p>
 
@@ -205,7 +205,9 @@ title: Community guidelines
         the appropriateness of our response, but we don't guarantee we'll act on it.
       </p>
 
-      <p>What if your report concerns a possible violation by a committee member?</p>
+      <h3 id="what-if-your-report-concerns-a-possible-violation-by-a-committee-member">
+        What if your report concerns a possible violation by a committee member?
+      </h3>
 
       <p>
         If your report concerns a current member of the Community Committee, you may not feel


### PR DESCRIPTION
Adjusts the wording (replacing "working group" with "committee") and formatting (fixed a missing heading) of the guidelines.