### PR TITLE
Remove header banner

### DIFF
--- a/source/partials/_header.erb
+++ b/source/partials/_header.erb
@@ -1,5 +1,4 @@
 <header class="site-header site-header--fixed">
-  <%= partial "partials/top_bar" %>
   <div class="navbar container">
     <div class="logo-wrapper">
       <a class="site-logo" href="/"><%= inline_svg("logo.svg", class: "isvg") %></a>

--- a/source/partials/_top_bar.html.erb
+++ b/source/partials/_top_bar.html.erb
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="top-bar-content">
       <a class="top-bar-content__link" href="https://conf.solidus.io/">
-        <p>Solidus Conf 2019  |  21-24 Oct 2019</p>
+        <p>Your message here!</p>
         <button class="top-bar-content__link__cta">Learn More</button>
       </a>
       <div class="top-bar-close">


### PR DESCRIPTION
This PR removes the top banner from the header since the Solidus Conf is ended. We'd use the banner for future announcements thought, so I didn't remove it totally.