### PR TITLE
Add "Newsbar" with Solidus YouTube channel link

### DIFF
--- a/source/assets/stylesheets/components/_newsbar.scss
+++ b/source/assets/stylesheets/components/_newsbar.scss
@@ -1,0 +1,34 @@
+.newsbar {
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 30px;
+  padding: 4px 15px;
+  background: rgba(0, 0, 0, 0.2);
+  color: $white;
+  border-radius: 5px;
+  font-size: 12px;
+
+  @include media-breakpoint-up(md){
+    max-width: 565px;
+    margin-top: -60px;
+    font-size: 14px;
+  }
+  
+  span {
+    text-transform: uppercase;
+    font-size: 10px;
+    color: $green;
+    font-weight: 700;
+    margin-right: 10px;
+  }
+
+  strong {
+    font-weight: 700;
+  }
+
+  a {
+    color: $white;
+    font-weight: 700;
+    text-decoration: underline;
+  }
+}

--- a/source/assets/stylesheets/site.scss
+++ b/source/assets/stylesheets/site.scss
@@ -11,6 +11,7 @@
 @import "helper";
 
 @import "components/top-bar";
+@import "components/newsbar";
 @import "components/text";
 @import "components/misc";
 @import "components/images";

--- a/source/assets/stylesheets/vendor/bootstrap/theme/_variables.scss
+++ b/source/assets/stylesheets/vendor/bootstrap/theme/_variables.scss
@@ -37,6 +37,8 @@ $blue-dark:    #264b99;
 
 $red:     #ff4848;
 
+$green:     #6BC78D;
+
 $primary:       $blue;
 $secondary:     $gray-200;
 

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -3,6 +3,9 @@
 
 <div class="content-block content-block-lg content-block-gray-900">
   <div class="container">
+    <div class="newsbar text-center">
+      <p><span>New</span>Did you miss SolidusConf 2019? <strong>All the talks are now available on </strong><a href="https://www.youtube.com/channel/UCiFcxyt11T6QIIDPk2w0Jjw" target="_blank" rel="noopener noreferrer nofollow" title="YouTube">YouTube</a>!</p>
+    </div>
     <div class="row align-items-center">
       <div class="col-md">
         <div class="block-content mb-4 mb-md-0">


### PR DESCRIPTION
### What:
This PR adds a little bar to the hero of the homepage, which promotes the videos recently uploaded to the Solidus [YouTube channel](https://www.youtube.com/channel/UCiFcxyt11T6QIIDPk2w0Jjw). 

### Why:
We never promoted the SolidusConf through the official website before. We should start adding more content related to the events we organize, starting from this little banner to a page dedicated to the events we organize. 

### Preview:
<img width="1191" alt="Schermata 2019-12-12 alle 15 35 34" src="https://user-images.githubusercontent.com/1730394/70720938-0edab180-1cf5-11ea-9e41-ac407bc60692.png">