### PR TITLE
Fix Developers link color

### DIFF
--- a/source/assets/stylesheets/components/_navigation.scss
+++ b/source/assets/stylesheets/components/_navigation.scss
@@ -163,10 +163,6 @@
       &:focus {
         outline: 0;
       }
-
-      @include media-breakpoint-up(lg){
-        color: $gray-900;
-      }
     }
     
     .dropdown-link {
@@ -219,6 +215,10 @@
         display: block;
         box-shadow: 0px 5px 40px rgba(36, 40, 47, 0.12);
         transform: translateY(20px);
+        
+        a {
+          color: $gray-900;
+        }
       }
   
       &.show {


### PR DESCRIPTION
**What:**
This PR fixes the "Developer" link color when other menu links are active.

**Before:**
<img width="1181" alt="Schermata 2020-01-17 alle 11 03 24" src="https://user-images.githubusercontent.com/1730394/72603324-19522180-3919-11ea-9a4f-f622f20d0f63.png">

**After:**
<img width="1179" alt="Schermata 2020-01-17 alle 11 03 59" src="https://user-images.githubusercontent.com/1730394/72603337-1ce5a880-3919-11ea-9a13-f8cf20694766.png">
