### PR TITLE
Show analytics tags in blog pages as well

### DIFF
--- a/source/layouts/blog.erb
+++ b/source/layouts/blog.erb
@@ -11,6 +11,8 @@
 
   <title><%= current_article.title unless current_article.nil? %> - Solidus</title>
 
+  <%= partial "partials/head_analytics" %>
+
   <%= javascript_include_tag "modernizr" %>
   <%= stylesheet_link_tag "site" %>
 </head>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -16,15 +16,7 @@
     <%= config[:seo_title] %>
   </title>
 
-  <% unless development? %>
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-K5854ZQ');</script>
-    <!-- End Google Tag Manager -->
-  <% end %>
+  <%= partial "partials/head_analytics" %>
 
   <%= javascript_include_tag "modernizr" %>
   <%= stylesheet_link_tag "site" %>

--- a/source/partials/_head_analytics.html.erb
+++ b/source/partials/_head_analytics.html.erb
@@ -1,0 +1,9 @@
+<% unless development? %>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-K5854ZQ');</script>
+  <!-- End Google Tag Manager -->
+<% end %>


### PR DESCRIPTION
Right now the Google Tag Manager script is not executed in the blog post layout.