### PR TITLE
Add Netlify badge

### DIFF
--- a/source/assets/stylesheets/components/_layout.scss
+++ b/source/assets/stylesheets/components/_layout.scss
@@ -63,6 +63,8 @@ body{
 
 //Page footer
 .site-footer {
+  padding-bottom: 50px !important;
+
   &__top {
     .footer-logo {
       margin-bottom: 50px;
@@ -144,6 +146,11 @@ body{
         margin-top: 0;
         text-align: right;
       }
+    }
+
+    .netlify-badge {
+      margin-top: 60px;
+      text-align: center;
     }
   }
 }

--- a/source/partials/_footer.erb
+++ b/source/partials/_footer.erb
@@ -69,6 +69,11 @@
           </ul>
         </div>
       </div>
+      <div class="netlify-badge">
+        <a href="https://www.netlify.com">
+          <img src="https://www.netlify.com/img/global/badges/netlify-dark.svg" alt="Deploys by Netlify" />
+        </a>
+      </div>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
This PR adds the Netlify badge to the website footer.

**Mobile:**
<img width="497" alt="Schermata 2020-03-13 alle 14 34 38" src="https://user-images.githubusercontent.com/1730394/76625572-d2a72f00-6537-11ea-9503-9e976cb5f4aa.png">

**Desktop:**
<img width="1252" alt="Schermata 2020-03-13 alle 14 34 53" src="https://user-images.githubusercontent.com/1730394/76625578-d63ab600-6537-11ea-9b2b-6c89c67e6b3d.png">
