### PR TITLE
Fix help center widget Slack link

### DIFF
--- a/source/assets/stylesheets/components/_help-center-widget.scss
+++ b/source/assets/stylesheets/components/_help-center-widget.scss
@@ -151,6 +151,7 @@
 
             h5 {
               margin: 0;
+              font-weight: 500;
             }
             p {
               font-size: $font-size-sm;

--- a/source/partials/_help_center_widget.html.erb
+++ b/source/partials/_help_center_widget.html.erb
@@ -32,7 +32,7 @@
         </a>
       </div>
       <div class="help-center-widget__content__body__card">
-        <a class="help-center-widget__content__body__card__content" href="/partners">
+        <a class="help-center-widget__content__body__card__content" href="http://slack.solidus.io" target="_blank">
           <%= inline_svg("icons/community.svg", class: "isvg") %>
           <div class="help-center-widget__content__body__card__content__text">
             <h5>Join our Slack!</h5>


### PR DESCRIPTION
This PR fixes the "Join our Slack" link in the Help Center widget.