### PR TITLE
Remove AOS attr where isn't required for animation

### DIFF
--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -63,7 +63,7 @@ title: Community
     <h2 class="title text-white">Join the Solidus Community.</h2>
     <p class="lead text-white-072">Connect and engage with a worldwide community of Solidus developers, stakeholders and experts all around the world.</p>
   </div>
-  <div class="container" data-aos="fade">
+  <div class="container">
     <div class="d-lg-flex justify-content-around">
       <div class="community-data pr-lg-1 pr-xl-2">
         <a href="http://slack.solidus.io/" target="_blank">
@@ -158,7 +158,7 @@ title: Community
   </div>
 </div>
 
-<div class="content-block content-block-gray-100" id="core-team" data-aos="fade">
+<div class="content-block content-block-gray-100" id="core-team">
   <div class="container container-md text-center mb-8">
     <h2 class="title">Meet the core team.</h2>
     <p>
@@ -387,7 +387,7 @@ title: Community
 </div>
 
 <div class="container border-bottom border-secondary text-center">
-  <div class="content-block container container-sm" data-aos="fade">
+  <div class="content-block container container-sm">
     <h2 class="title">Our Donors.</h2>
     <p>
       As a community-driven, open-source project, Solidus development and
@@ -403,7 +403,7 @@ title: Community
 
 <%= partial "partials/members_list" %>
 
-<div class="donor-block content-block content-block-gray-900 position-relative p-md-0 pb-0" data-aos="fade">
+<div class="donor-block content-block content-block-gray-900 position-relative p-md-0 pb-0">
   <div class="container">
     <div class="row">
       <div class="donor-content col-md-6">
@@ -427,7 +427,7 @@ title: Community
 
 <%= partial "partials/contributors_list" %>
 
-<div class="call-to-action content-block text-center" data-aos="fade">
+<div class="call-to-action content-block text-center">
   <div class="container container-md">
     <h3 class="title">Ready to become a contributor?</h3>
     <a class="btn btn-primary btn-w-icon btn-lg" href="https://github.com/solidusio/solidus" target="_blank"><%= inline_svg("social-icons/github.svg", class: "isvg") %> <span class="text">Fork Solidus on GitHub</span></a>

--- a/source/extensions.html.erb
+++ b/source/extensions.html.erb
@@ -11,7 +11,7 @@ title: Extensions
   <img class="img-fluid" src="<%= image_path('illustrations/extensions.png') %>" srcset="<%= image_path('illustrations/extensions.png') %>, <%= image_path('illustrations/extensions@2x.png') %> 2x" alt="Extensions">
 </div>
 
-<div class="extensions-filter" data-aos="fade">
+<div class="extensions-filter">
   <div class="container">
     <h6 class="title">Show:</h6>
 
@@ -43,7 +43,7 @@ title: Extensions
 
 <% extensions = Solidus::Extension.from_yaml_data(data.extensions, environment: environment) %>
 
-<div class="extensions-list-block content-block content-block-gray-100" data-aos="fade">
+<div class="extensions-list-block content-block content-block-gray-100">
   <div class="container">
     <div class="alert alert-warning mb-0 d-none" role="alert">
       No extensions matching your criteria
@@ -72,7 +72,7 @@ title: Extensions
   </div>
 </div>
 
-<div class="content-block" data-aos="fade">
+<div class="content-block">
   <div class="container">
     <div class="row align-items-center">
       <div class="col-md">

--- a/source/features.html.erb
+++ b/source/features.html.erb
@@ -18,7 +18,7 @@ title: Features
        alt="Edit Product">
 </div>
 
-<div class="features-main-block content-block content-block-gray-100" data-aos="fade">
+<div class="features-main-block content-block content-block-gray-100">
   <div class="container">
     <h2 class="title text-center mb-4 mb-md-6">Our open source code works for you.</h2>
     <div class="row justify-content-around">
@@ -64,7 +64,7 @@ title: Features
   </div>
 </div>
 
-<div class="features-details-block content-block" data-aos="fade">
+<div class="features-details-block content-block">
   <div class="container">
     <h2 class="title">All the features.</h2>
     <p class="lead mb-5 mb-md-8">
@@ -332,7 +332,7 @@ title: Features
   </div>
 </div>
 
-<div class="content-block content-block-gray-100" data-aos="fade">
+<div class="content-block content-block-gray-100">
   <div class="container">
     <div class="row align-items-center">
       <div class="col-md">
@@ -356,7 +356,7 @@ title: Features
   </div>
 </div>
 
-<div class="call-to-action content-block text-center" data-aos="fade">
+<div class="call-to-action content-block text-center">
   <div class="container container-md">
     <h3 class="title">Have a question? <span class="d-block">Ask the community.</span></h3>
     <a class="btn btn-primary btn-w-icon btn-lg" href="http://slack.solidus.io/" target="_blank"><%= inline_svg("social-icons/slack.svg", class: "isvg") %> <span class="text">Join our Slack</span></a>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -36,21 +36,21 @@ description: Solidus is the free, open-source, Ruby on Rails eCommerce platform 
   
   <div class="intro content-block--skewed content-block-gray-100">
     <div class="content-wrapper pt-0 pb-0">
-      <div class="content-block pt-0" data-aos="fade">
+      <div class="content-block pt-0">
         <div class="container">
           <p class="lead text-gray-600 text-center font-weight-light mb-4">Solidus powers the brands defining the future of eCommerce.</p>
           <%= partial "partials/community_logos" %>
         </div>
       </div>
       
-      <div class="container container-md text-center" data-aos="fade">
+      <div class="container container-md text-center">
         <h2 class="title">Yours to customize, yours forever.</h2>
         <p class="lead">
           Free your business from meaningless boundaries. Solidus gives you the freedom to experiment, change and develop. Start small, grow huge: find what’s really important for your business and make it happen.
         </p>
       </div>
 
-      <div class="features-section first container" data-aos="fade">
+      <div class="features-section first container">
         <div class="content-block">
           <div class="row align-items-center">
             <div class="features-section--image tab-content col-md">
@@ -111,7 +111,7 @@ description: Solidus is the free, open-source, Ruby on Rails eCommerce platform 
         </div>
       </div>
 
-      <div class="features-section second container" data-aos="fade">
+      <div class="features-section second container">
         <div class="content-block p-0">
           <div class="row align-items-center">
             <div class="features-section--image tab-content col-md order-md-2">
@@ -182,9 +182,9 @@ description: Solidus is the free, open-source, Ruby on Rails eCommerce platform 
     </div>
     
     <div class="container">
-      <div class="content-block" data-aos="fade">
-        <div class="row align-items-center content-block-gray-900" data-aos="fade">
-          <div class="col-md-5 col-lg-6 col-xl-7">
+      <div class="content-block">
+        <div class="row align-items-center content-block-gray-900">
+          <div class="col-md-5 col-lg-6 col-xl-7"  data-aos="fade">
             <div class="pr-md-6">
               <%= partial 'partials/community_stats', locals: { type: 'github', count: '3000', title: 'GitHub stars' } %>
               <%= partial 'partials/community_stats', locals: { type: 'slack', count: '2900', title: 'Slack members' } %>

--- a/source/layouts/blog.erb
+++ b/source/layouts/blog.erb
@@ -36,7 +36,7 @@
     <%= yield %>
   </div>
 
-  <div class="content-block text-center" data-aos="fade">
+  <div class="content-block text-center">
     <div class="social-plugins-block">
       <div class="social-btn">
         <a class="twitter-share-button" href="https://twitter.com/share" data-text="<%= current_page.data.title %>" data-url="<%= config.base_url %><%= current_page.url %>" data-hashtags="solidus">Tweet</a>

--- a/source/partials/_contributors_list.html.erb
+++ b/source/partials/_contributors_list.html.erb
@@ -1,12 +1,10 @@
 <div class="content-block content-block-gray-100 community-contributors">
   <div class="container text-center">
-    <div data-aos="fade">
-      <h2 class="title">Contributors.</h2>
-      <p class="mb-8">
-        Solidus is free and open source software, made possible by the work of dozens of volunteers.
-        <a class="link" href="https://github.com/solidusio/solidus" target="_blank">Join us!</a>
-      </p>
-    </div>
+    <h2 class="title">Contributors.</h2>
+    <p class="mb-8">
+      Solidus is free and open source software, made possible by the work of dozens of volunteers.
+      <a class="link" href="https://github.com/solidusio/solidus" target="_blank">Join us!</a>
+    </p>
 
     <ul class="list-inline">
       <% github_contributors.each do |user| %>

--- a/source/partials/_members_list.html.erb
+++ b/source/partials/_members_list.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="content-block border-bottom border-secondary" data-aos="fade">
+  <div class="content-block border-bottom border-secondary">
     <div class="container container-md mb-8 text-center">
       <%= inline_svg("icons/key-stakeholder.svg", class: "isvg") %>
       <h3 class="title mt-3">Ambassadors</h3>
@@ -29,7 +29,7 @@
     </div>
   </div>
 
-  <div class="content-block border-bottom border-secondary" data-aos="fade">
+  <div class="content-block border-bottom border-secondary">
     <div class="container container-md mb-8 text-center">
       <%= inline_svg("icons/sponsor.svg", class: "isvg") %>
       <h4 class="title mt-3">Supporters</h4>
@@ -61,7 +61,7 @@
     </div>
   </div>
 
-  <div class="content-block border-bottom border-secondary" data-aos="fade">
+  <div class="content-block border-bottom border-secondary">
     <div class="container container-md mb-8 text-center">
       <%= inline_svg("icons/backer.svg", class: "isvg") %>
       <h4 class="title mt-3">Enthusiasts</h4>

--- a/source/partials/_partners_list.html.erb
+++ b/source/partials/_partners_list.html.erb
@@ -1,4 +1,4 @@
-<div class="partners-main-block content-block content-block-gray-100" id="partners-list" data-aos="fade">
+<div class="partners-main-block content-block content-block-gray-100" id="partners-list">
   <div class="container container-md">
     <div class="d-flex justify-content-center mb-3">
       <%= inline_svg("icons/partners-main.svg", class: "isvg align-self-start mr-3") %>

--- a/source/partners.html.erb
+++ b/source/partners.html.erb
@@ -21,7 +21,7 @@ title: Partners
   </div>
 </div>
 
-<div class="partners-detail-block content-block" data-aos="fade">
+<div class="partners-detail-block content-block">
   <div class="container">
     <h2 class="title text-center mb-4 mb-md-6">How a Solidus Partner can help you.</h2>
     <div class="row justify-content-around">
@@ -73,7 +73,7 @@ title: Partners
 
 <%= partial "partials/partners_list" %>
 
-<div class="content-block content-block-gray-900 p-md-0 pb-0" id="become-a-partner" data-aos="fade">
+<div class="content-block content-block-gray-900 p-md-0 pb-0" id="become-a-partner">
   <div class="container">
     <div class="row align-items-center">
       <div class="col-md">
@@ -91,7 +91,7 @@ title: Partners
   </div>
 </div>
 
-<div class="call-to-action content-block text-center" data-aos="fade">
+<div class="call-to-action content-block text-center">
   <div class="container container-md">
     <h3 class="title">Ready to become a Partner?</h3>
     <a class="btn btn-primary btn-lg" href="https://solidusio.typeform.com/to/IiIPeI" target="_blank">Sure!</a>


### PR DESCRIPTION
With the aim of testing and optimizing the new Home Page, the AOS js (that gives the fade effect on scrolling page, to the content wrappers) has been deleted. 
This because we learned that it compromises the correct reading of tools such as the Heatmap.
For now, we limiting the use of AOS.js only where an animation has to start when actually it has showed.

The next step is to find a lightweight js that can replace AOS library.