### PR TITLE
Improve contact form UX

### DIFF
--- a/source/assets/stylesheets/vendor/bootstrap/theme/_forms.scss
+++ b/source/assets/stylesheets/vendor/bootstrap/theme/_forms.scss
@@ -4,79 +4,30 @@
 // Textual form controls
 //
 
-.form-control {
-  padding: $input-padding-y $input-padding-x;
+.form-group {
+  margin-bottom: 20px;
 
-  &:hover{
-    border-color: $input-hover-border-color;
-    box-shadow: 0 0 0 1px $input-hover-border-color;
-
-    &::placeholder {
-      color: $body-color;
-    }
-  }
-
-  &:focus{
-    border-color: $input-focus-border-color;
-    box-shadow: 0 0 0 1px $input-focus-border-color;
-  }
-}
-
-//Float label inputs
-.has-float-label {
-  margin-bottom: 0;
-  position: relative;
-
-  label, .form-control, .form-control::placeholder {
-    transition-property: padding, opacity, color, background-color, font-size;
-    transition-duration: .3s;
-  }
-
-  label{
-    background: transparent;
-    color: $input-placeholder-color;
-    font-size: $font-size-base;
-    left: 1px;
-    line-height: $input-line-height;
-    margin: 0;
-    overflow: hidden;
-    padding: $input-padding-y $input-padding-x 0;
-    position: absolute;
-    text-align: left;
-    text-overflow: ellipsis;
-    top: 1px;
-    white-space: nowrap;
-    width: calc(100% - 2px);
-    z-index: 2;
+  label {
+    font-weight: $font-weight-bold;
   }
 
   .form-control {
-    position: relative;
-    z-index: 2;
-
-    &:not(:placeholder-shown), &:focus{
-      background: $input-bg;
-      padding-top: 25px;
-      padding-bottom: 7px;
-
-      &::placeholder { opacity: 0; }
-
-      & + label{
-        background: #ffffff;
-        font-size: 12px;
-        padding-top: 8px;
-
+    padding: $input-padding-y $input-padding-x;
+    background: $gray-100;
+    border-color: $gray-300;
+    border-radius: 4px;
+  
+    &:hover{
+      border-color: $input-hover-border-color;
+  
+      &::placeholder {
+        color: $body-color;
       }
     }
-  }
-
-  textarea.form-control + label{
-    width: calc(100% - 20px);
-  }
-
-  textarea.form-control:not(:placeholder-shown), textarea.form-control:focus {
-    & + label {
-      z-index: 3;
+  
+    &:focus{
+      border-color: $input-focus-border-color;
+      box-shadow: none;
     }
   }
 }

--- a/source/assets/stylesheets/vendor/bootstrap/theme/_variables.scss
+++ b/source/assets/stylesheets/vendor/bootstrap/theme/_variables.scss
@@ -219,19 +219,18 @@ $btn-box-shadow:              none;
 $input-padding-y-top:                   18px;
 $input-padding-y-bottom:                14px;
 $input-padding-x:                       16px;
-$input-padding-y:                       16px;
+$input-padding-y:                       13px;
 $input-line-height:                     $line-height-base;
 
 $input-color:                           $gray-700;
 $input-border-color:                    $gray-200;
 $input-hover-border-color:              #cacbcc;
-$input-focus-border-color:              #7e7f80;
+$input-focus-border-color:              #cacbcc;
 $input-border-width:                    $border-width;
 $input-box-shadow:                      none;
 
 $input-placeholder-color:               $gray-500;
 
-$input-focus-border-color:              $gray-600;
 $input-focus-color:                     $input-color;
 $input-focus-width:                     1px;
 

--- a/source/contact.html.erb
+++ b/source/contact.html.erb
@@ -19,7 +19,7 @@ title: Contact
         </div>
         <div class="form-group mb-3">
           <label for="inputMessage">Message *</label>
-          <textarea class="form-control" name="inputMessage" id="inputMessage" rows="10" required></textarea>  
+          <textarea class="form-control" name="inputMessage" id="inputMessage" rows="6" required></textarea>  
         </div>
         <small class="d-block mb-3">* Required fields</small>
         <div data-netlify-recaptcha="true"></div>

--- a/source/contact.html.erb
+++ b/source/contact.html.erb
@@ -10,23 +10,18 @@ title: Contact
     <form class="contact-form" action="/contact/success" method="POST" name="contact" data-netlify="true">
       <fieldset>
         <div class="form-group">
-          <div class="has-float-label">
-            <input type="text" class="form-control " name="inputName" id="inputName" placeholder="Name" required>
-            <label for="inputName">Name</label>
-          </div>
+          <label for="inputName">Name *</label>
+          <input type="text" class="form-control " name="inputName" id="inputName" required>  
         </div>
         <div class="form-group">
-          <div class="has-float-label">
-            <input type="email" class="form-control" name="inputEmail" id="inputEmail" placeholder="Email" required>
-            <label for="inputEmail">Email</label>
-          </div>
+          <label for="inputEmail">Email *</label>
+          <input type="email" class="form-control" name="inputEmail" id="inputEmail" required>  
         </div>
         <div class="form-group mb-3">
-          <div class="has-float-label">
-            <textarea class="form-control" name="inputMessage" id="inputMessage" rows="10" placeholder="Message" required></textarea>
-            <label for="inputMessage">Message</label>
-          </div>
+          <label for="inputMessage">Message *</label>
+          <textarea class="form-control" name="inputMessage" id="inputMessage" rows="10" required></textarea>  
         </div>
+        <small class="d-block mb-3">* Required fields</small>
         <div data-netlify-recaptcha="true"></div>
         <div class="text-center mt-1">
           <button class="btn btn-primary btn-block" type="submit">Send</button>


### PR DESCRIPTION
### What
This PR improves the contact form user experience by changing the way labels are displayed and indicating the required fields to the user.

### Why
I was looking for a way to fix the floating label bug on Safari, but I thought that it would be better to change the way labels are displayed moving them outside the input field to reduce user errors. ([read this article](https://www.nngroup.com/articles/form-design-placeholders/) for more info). 

### Before
<img width="574" alt="Schermata 2020-04-24 alle 15 20 28" src="https://user-images.githubusercontent.com/1730394/80226352-8c6fe000-864c-11ea-8f8d-574b3e4fe4a1.png">

### After
<img width="637" alt="Schermata 2020-04-24 alle 16 57 50" src="https://user-images.githubusercontent.com/1730394/80226542-c8a34080-864c-11ea-91bc-da1e6cedfcac.png">
