### PR TITLE
Fix newsletter button background color on Safari

### DIFF
--- a/source/partials/_newsletter_form.html.erb
+++ b/source/partials/_newsletter_form.html.erb
@@ -5,7 +5,7 @@
     <input type="email" value="" name="EMAIL" class="email form-control" id="mce-EMAIL" placeholder="Enter your email" required>
     <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
     <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_679f4835b2683d59bc5762ec3_3ce07e9582" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Sign up" name="subscribe" id="mc-embedded-subscribe" class="button btn"></div>
+    <div class="clear"><input type="submit" value="Sign up" name="subscribe" id="mc-embedded-subscribe" class="button btn btn-white"></div>
   </div>
   </form>
 </div>


### PR DESCRIPTION
### What
This PR fixes the background color of the Mailchimp newsletter button on Safari.

### Before
<img width="379" alt="Schermata 2020-04-24 alle 18 40 02" src="https://user-images.githubusercontent.com/1730394/80236383-5423ce00-865b-11ea-97f7-7e57471f5d89.png">

### After
<img width="349" alt="Schermata 2020-04-24 alle 18 38 30" src="https://user-images.githubusercontent.com/1730394/80236372-525a0a80-865b-11ea-8566-b60ad8018c8e.png">