### PR TITLE
Change padding units to rem

### DIFF
--- a/source/assets/stylesheets/vendor/bootstrap/theme/_variables.scss
+++ b/source/assets/stylesheets/vendor/bootstrap/theme/_variables.scss
@@ -216,10 +216,10 @@ $btn-box-shadow:              none;
 
 
 // Forms
-$input-padding-y-top:                   18px;
-$input-padding-y-bottom:                14px;
-$input-padding-x:                       16px;
-$input-padding-y:                       13px;
+$input-padding-y-top:                   1.125rem;
+$input-padding-y-bottom:                0.875rem;
+$input-padding-x:                       1rem;
+$input-padding-y:                       0.8125rem;
 $input-line-height:                     $line-height-base;
 
 $input-color:                           $gray-700;


### PR DESCRIPTION
Bootstrap v4 changed the default units from px to rem. Future version of
bootstrap throw an error on incompatible units in calc. Changing these
px values to rem values will allow us to upgrade to newer versions of
Bootstrap without error.