### PR TITLE
update ci for solidus_user_roles

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -1,6 +1,6 @@
 ---
 boomerdigital/solidus_user_roles:
-  ci_provider: travis
+  ci_provider: circleci
   title: User Roles
   description: Add support for advanced roles and authorization management to your store's backend.
   group: Authentication


### PR DESCRIPTION
They're using circle-ci now https://github.com/boomerdigital/solidus_user_roles

Btw, I think `Authorization` will be a more accurate group for this extension