### PR TITLE
Add the GA attribute to track CTAs on home page

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -14,7 +14,7 @@ description: Solidus is the free, open-source eCommerce platform based on Ruby o
               free, open-source eCommerce framework for digitally-native brands, fast-growing online
               businesses and pragmatic developers.
             </p>
-            <a class="btn btn-primary btn-lg" href="/contact">Get started</a>
+            <a class="btn btn-primary btn-lg" href="/contact" onclick="ga('send', 'event', 'GetStarted', 'ContactUs', 'HomePage');">Get started</a>
             <div class="mt-4 mb-4">
               <%= inline_svg("icons/check-circle-green.svg", class: "isvg") %>
               <span class="pr-sm-4 pr-2">
@@ -302,7 +302,7 @@ description: Solidus is the free, open-source eCommerce platform based on Ruby o
   <div class="call-to-action content-block content-block-white text-center">
     <div class="container container-md">
       <h3 class="title">Join the brands that are changing the future of eCommerce.</h3>
-      <a class="btn btn-primary btn-lg" href="/contact">Get started</a>
+      <a class="btn btn-primary btn-lg" href="/contact" onclick="ga('send', 'event', 'GetStarted', 'ContactUs', 'HomePage');">Get started</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
We'd like to track all the CTAs with Google Analytics; I've noticed that it could be done via Google Tag Manager or creating a new Goal as Event type (in GA) with Category and Label attributes. Then it should be enough to add this attribute to the link, i.e.:

`<a href="/contact" onclick="ga('send', 'event', 'GetStarted', 'ContactUs', 'HomePage');">Get started</a>`

These are the sources that I read about this topic: 

- https://developers.google.com/analytics/devguides/collection/analyticsjs/events
- https://analytical42.com/2016/event-tracking-example-ga-autotrack/