### PR TITLE
Remove the active state from the Features page

### DIFF
--- a/source/partials/_header.erb
+++ b/source/partials/_header.erb
@@ -5,7 +5,7 @@
     </div>
 
     <nav class="site-menu" role="navigation">
-      <ul class="menu-items <%= nav_inactive(["features.html", "community.html", "blog/", "partners.html"]) %>">
+      <ul class="menu-items <%= nav_inactive(["community.html", "blog/", "partners.html"]) %>">
         <li class="nav-item dropdown">
           <a class="dropdown-link" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">Product</a>
           <div class="dropdown-menu">


### PR DESCRIPTION
This PR removes the active link state from the Features page since after some changes to the website structure it's no longer a first-level navigation link.

**Before:**
<img width="1235" alt="Schermata 2020-06-19 alle 13 40 04" src="https://user-images.githubusercontent.com/1730394/85128872-6c1a6700-b232-11ea-9450-de953940f6e4.png">

**After:**
<img width="1189" alt="Schermata 2020-06-19 alle 13 40 14" src="https://user-images.githubusercontent.com/1730394/85128880-70468480-b232-11ea-8883-08e8ea188fcd.png">

