### PR TITLE
Display the top banner of the Solidus Conf 2020

### DIFF
--- a/source/assets/javascripts/common.js
+++ b/source/assets/javascripts/common.js
@@ -100,12 +100,12 @@ $(function () {
 
   //Remove top bar on click
   if (!Cookies.get('announcement')) {
-    $(".top-bar").addClass('top-bar--show');
+    $(".top-bar, body").addClass('top-bar--show');
   }
 
   $(".top-bar-close").click(function(){
     Cookies.set('announcement', 'true', { expires: 10 });
-    $(".top-bar").removeClass('top-bar--show');
+    $(".top-bar, body").removeClass('top-bar--show');
   });
 
   $('[data-toggle="tooltip"]').tooltip();

--- a/source/assets/stylesheets/components/_layout.scss
+++ b/source/assets/stylesheets/components/_layout.scss
@@ -23,7 +23,13 @@ body{
     &.menu-open{ overflow: hidden; }
   }
 
-  @include media-breakpoint-up(lg) { padding-top: $desktop-header-height; }
+  @include media-breakpoint-up(lg) {
+    padding-top: $desktop-header-height;
+    
+    &.top-bar--show {
+      padding-top: $desktop-header-height + 40px;
+    }
+  }
 }
 
 //Sticky footer styles

--- a/source/assets/stylesheets/components/_top-bar.scss
+++ b/source/assets/stylesheets/components/_top-bar.scss
@@ -5,9 +5,14 @@
   font-size: 14px;
   font-weight: bold;
   display: none;
+  min-height: 40px;
 
   &--show {
     display: block;
+    
+    .menu-open & {
+      display: none;
+    }
   }
   
   .top-bar-content {

--- a/source/partials/_header.erb
+++ b/source/partials/_header.erb
@@ -1,4 +1,5 @@
 <header class="site-header site-header--fixed <%= "site-header--blue" if current_page.data.title == 'Integrations' %> <%= "site-header--dark" if current_page.data.title == 'Roadmap' %>">
+  <%= partial "partials/top_bar" %>
   <div class="navbar container">
     <div class="logo-wrapper">
       <a class="site-logo" href="/"><%= inline_svg("logo.svg", class: "isvg") %></a>

--- a/source/partials/_top_bar.html.erb
+++ b/source/partials/_top_bar.html.erb
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="top-bar-content">
       <a class="top-bar-content__link" href="https://conf.solidus.io/">
-        <p>Your message here!</p>
+        <p>Solidus Digital Conf 2020 | 23-25 Sept 2020</p>
         <button class="top-bar-content__link__cta">Learn More</button>
       </a>
       <div class="top-bar-close">


### PR DESCRIPTION
The Conference is near and is better to share it also on the Solidus site!

I've picked the past top-bar banner and did some minor fixes to display it well on all the new pages of the website.

<img width="1229" alt="Schermata 2020-07-16 alle 17 58 18" src="https://user-images.githubusercontent.com/46188345/87694005-eedd0600-c78d-11ea-98bc-b9cf3056cfff.png">
