### PR TITLE
Remove user guides links from the Developers menu

### DIFF
--- a/source/assets/stylesheets/components/_navigation.scss
+++ b/source/assets/stylesheets/components/_navigation.scss
@@ -247,7 +247,7 @@
       }
 
       &--multi {
-        min-width: 500px;
+        min-width: 450px;
         
         &.expandable {
           min-width: 1px;

--- a/source/partials/_header.erb
+++ b/source/partials/_header.erb
@@ -38,12 +38,6 @@
                 <a href="https://guides.solidus.io/developers/extensions/installing-extensions.html" target="_blank" rel="noopener noreferrer">Installing extensions</a>
               </div>
               <div class="dropdown-top__list">
-                <a href="https://guides.solidus.io/users/index.html" target="_blank" rel="noopener noreferrer">Users</a>
-                <a href="https://guides.solidus.io/users/orders/overview.html" target="_blank" rel="noopener noreferrer">Orders</a>
-                <a href="https://guides.solidus.io/users/products/overview.html" target="_blank" rel="noopener noreferrer">Products</a>
-                <a href="https://guides.solidus.io/users/settings/overview.html" target="_blank" rel="noopener noreferrer">Settings</a>
-              </div>
-              <div class="dropdown-top__list">
                 <a href="https://solidus.docs.stoplight.io/" target="_blank" rel="noopener noreferrer">API</a>
                 <a href="https://solidus.docs.stoplight.io/authentication" target="_blank" rel="noopener noreferrer">Authentication</a>
                 <a href="https://solidus.docs.stoplight.io/checkout-flow" target="_blank" rel="noopener noreferrer">Checkout Flow</a>


### PR DESCRIPTION
This PR removes the user guides links from the Developers menu.

### Before:
<img width="659" alt="Schermata 2020-07-17 alle 15 21 42" src="https://user-images.githubusercontent.com/1730394/87790724-530cd200-c841-11ea-8605-7385d0174125.png">

### After:
<img width="675" alt="Schermata 2020-07-17 alle 15 20 49" src="https://user-images.githubusercontent.com/1730394/87790733-5902b300-c841-11ea-9f5c-5721f57c591e.png">
