### PR TITLE
Fix use case logos

### DIFF
--- a/data/use_cases_logos.yml
+++ b/data/use_cases_logos.yml
@@ -35,26 +35,11 @@ headless_commerce_logos:
     logo: "ace&tate.svg"
     url: https://www.aceandtate.com
 
-  bookshop:
-    name: "Bookshop"
-    logo: "bookshop.svg"
-    url: https://bookshop.org
-
 marketplace_logos:
   maisonette:
     name: "Maisonette"
     logo: "maisonette.svg"
     url: https://www.maisonette.com
-
-  glossier:
-    name: "Glossier"
-    logo: "glossier.svg"
-    url: https://www.glossier.com
-
-  moddedeuros:
-    name: "Modded Euros"
-    logo: "moddedeuros.svg"
-    url: https://www.moddedeuros.com
 
   bevv:
     name: "Bevv"


### PR DESCRIPTION
Some of the logos on the Use Cases pages were misplaced, probably because they'd been put there as placeholders.