### PR TITLE
Add Solidus Paypal Commerce Platform to extensions page

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -303,3 +303,8 @@ hefan/solidus_dynamic_variants:
   title: Dynamic Variants
   description: Creates variants from selected options on the fly during cart populate
   group: Products
+solidusio-contrib/solidus_paypal_commerce_platform:
+  ci_provider: circleci
+  title: PayPal Commerce Platform
+  description: Use PayPal to accept PayPal and credit/debit card payments
+  group: Payments


### PR DESCRIPTION
Adds the Solidus Paypal Commerce Platform extension to the payments section of the extensions page. 

The extension is currently _not_ located as solidusio-contrib - I will undraft this once it is! It's currently located at: https://github.com/nebulab/solidus_paypal_commerce_platform