### PR TITLE
Adjust z-index of the page menu - Integrations

### DIFF
--- a/source/assets/stylesheets/components/_integrations.scss
+++ b/source/assets/stylesheets/components/_integrations.scss
@@ -19,7 +19,7 @@
   }
   
   @include media-breakpoint-up(lg) {
-    z-index: $zindex-fixed + 1;
+    z-index: $zindex-fixed - 1;
     position: sticky;
   }
   


### PR DESCRIPTION
The z-index has been adjusted to avoid this situation:
<img width="857" alt="Schermata_2020-08-12_alle_15 25 03" src="https://user-images.githubusercontent.com/46188345/90118982-4785cb80-dd59-11ea-8a5d-cdd52c5783d9.png">
