### PR TITLE
Upgrade jquery version to avoid accordion's issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bootstrap": "4.3.1",
     "details-element-polyfill": "^2.3.1",
     "headroom.js": "0.9.4",
-    "jquery": "^3.5.0",
+    "jquery": "^3.5.1",
     "js-cookie": "^2.2.1",
     "popper.js": "^1.12.9",
     "slick-carousel": "^1.8.1",

--- a/source/assets/javascripts/common.js
+++ b/source/assets/javascripts/common.js
@@ -1,4 +1,3 @@
-import "jquery";
 import "popper.js";
 import "bootstrap";
 import "details-element-polyfill";

--- a/source/assets/javascripts/extensions.js
+++ b/source/assets/javascripts/extensions.js
@@ -1,4 +1,3 @@
-import "jquery";
 import AOS from "aos";
 
 $(function () {

--- a/source/features.html.erb
+++ b/source/features.html.erb
@@ -74,7 +74,7 @@ description: Solidus can flex, adjust and extend as you deliver your customers a
       your store.
     </p>
 
-    <div class="features-groups accordion">
+    <div class="features-groups accordion" id="accordion">
       <div class="features-group accordion-item">
         <h3 class="title">
           <a class="" href="#" data-toggle="collapse" data-target="#collapse1">


### PR DESCRIPTION
Ref. to https://github.com/solidusio/solidus-site/issues/328

I've upgraded the `jquery` version on the `package.json` as suggested [here](https://stackoverflow.com/questions/61177140/uncaught-typeerror-cannot-convert-object-to-primitive-valuezone-evergreen-js1) and add the `id` to the accordion container (suggestion [here](https://stackoverflow.com/a/56911025)).
