### PR TITLE
Let overflow-y as auto, on the mobile menu

### DIFF
--- a/source/assets/stylesheets/components/_navigation.scss
+++ b/source/assets/stylesheets/components/_navigation.scss
@@ -91,6 +91,8 @@
     padding: 0 30px;
     margin-bottom: 0;
     width: 100%;
+    overflow-y: auto;
+    overflow-x: hidden;
 
     a {
       color: #ffffff;


### PR DESCRIPTION
The issue was: when you had most of the menu items open, the main container didn't allow scrolling.