### PR TITLE
Update Footer links

### DIFF
--- a/source/partials/_footer.erb
+++ b/source/partials/_footer.erb
@@ -34,7 +34,13 @@
             <a class="text-white" href="/integrations">Integrations</a>
           </li>
           <li class="footer-links-item">
+            <a class="text-white" href="/blog">Blog</a>
+          </li>
+          <li class="footer-links-item">
             <a class="text-white" href="/security">Security</a>
+          </li>
+          <li class="footer-links-item">
+            <a class="text-white" href="https://github.com/solidusio/solidus/blob/master/CHANGELOG.md" target="_blank">Product changelog</a>
           </li>
           <li class="footer-links-item">
             <a class="text-white" href="/partners">Become a partner</a>
@@ -59,6 +65,26 @@
         </ul>
       </div>
       <div class="site-footer__sitemap__item">
+        <h6 class="text-white-048">Industries</h6>
+        <ul class="footer-links">
+          <li class="footer-links-item">
+            <a class="text-white" href="/industries/automotive">Automotive</a>
+          </li>
+          <li class="footer-links-item">
+            <a class="text-white" href="/industries/home-decor">Home Decor</a>
+          </li>
+          <li class="footer-links-item">
+            <a class="text-white" href="/industries/apparel">Apparel</a>
+          </li>
+          <li class="footer-links-item">
+            <a class="text-white" href="/industries/health-and-beauty">Health and Beauty</a>
+          </li>
+          <li class="footer-links-item">
+            <a class="text-white" href="/industries/food-and-beverage">Food and Beverage</a>
+          </li>
+        </ul>
+      </div>
+      <div class="site-footer__sitemap__item">
         <h6 class="text-white-048">Community</h6>
         <ul class="footer-links">
           <li class="footer-links-item">
@@ -72,17 +98,6 @@
           </li>
           <li class="footer-links-item">
             <a class="text-white" href="/community-guidelines">Community Guidelines</a>
-          </li>
-        </ul>
-      </div>
-      <div class="site-footer__sitemap__item">
-        <h6 class="text-white-048">News</h6>
-        <ul class="footer-links">
-          <li class="footer-links-item">
-            <a class="text-white" href="/blog">Blog</a>
-          </li>
-          <li class="footer-links-item">
-            <a class="text-white" href="https://github.com/solidusio/solidus/blob/master/CHANGELOG.md" target="_blank">Product changelog</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
The PR updates the website footer adding the links to the Industries pages. 
I moved the links in the “News” column under the “Solidus” one to get more space.

### Before
<img width="1378" alt="Schermata 2020-08-28 alle 14 30 53" src="https://user-images.githubusercontent.com/1730394/91561033-24534280-e93b-11ea-9f26-ad8b98272e5e.png">

### After
<img width="1358" alt="Schermata 2020-08-28 alle 14 31 13" src="https://user-images.githubusercontent.com/1730394/91561037-287f6000-e93b-11ea-9649-8046f6eb7e0f.png">
