### PR TITLE
Update homepage usage stats

### DIFF
--- a/data/project_stats.yml
+++ b/data/project_stats.yml
@@ -1,4 +1,4 @@
-github_stars: 3259
-slack_members: 3198
-open_collective_donations: 65
-contributors: 225
+github_stars: 3282
+slack_members: 3297
+open_collective_donations: 112
+contributors: 232


### PR DESCRIPTION
The amount of donations on OC has been switched from yearly to collected from the start of the OC fund.

This closes #378 