### PR TITLE
Remove the JS that overrides the Gh Star button

### DIFF
--- a/source/layouts/blog.erb
+++ b/source/layouts/blog.erb
@@ -63,7 +63,6 @@
 
 <%= javascript_include_tag "vendor" %>
 <%= javascript_include_tag "common" %>
-<script async defer src="https://buttons.github.io/buttons.js"></script>
 <%= yield_content :scripts %>
 
 <!--Social scrtipts-->


### PR DESCRIPTION
Ref. to #356 
The old JS that managed the Gh Star button, has been removed also from the blog layout.