### PR TITLE
Add Demo CTA to the Homepage

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -15,6 +15,7 @@ description: Solidus is the free, open-source eCommerce platform based on Ruby o
               businesses and pragmatic developers.
             </p>
             <a class="btn btn-primary btn-lg" href="/contact">Get started</a>
+            <a class="btn btn-secondary btn-white" href="http://solidemo.herokuapp.com/" target="_blank">Demo</a>
             <div class="mt-4 mb-4">
               <%= inline_svg("icons/check-circle-green.svg", class: "isvg") %>
               <span class="pr-sm-4 pr-2">


### PR DESCRIPTION
This PR adds a button to the Homepage that links to the [Solidus Demo](http://solidemo.herokuapp.com/).

From what we've seen from the Industries and Use Cases pages heatmaps, it seems like users tend to click on the Demo button rather than "Get started". 

I think it's worth trying and testing the button also on the homepage since it's a minimal change.