### PR TITLE
Reduce sub-navbar height

### DIFF
--- a/source/assets/stylesheets/components/_sub-navbar.scss
+++ b/source/assets/stylesheets/components/_sub-navbar.scss
@@ -1,6 +1,6 @@
 .sub-navbar {
   background: $white;
-  padding: 26px 0;
+  padding: 20px 0;
   top: 0;
   border-bottom: 1px solid $gray-200;
 


### PR DESCRIPTION
This PR reduces the sub-navbar height in order to be fully covered by the main header while scrolling up.

**Before:**
<img width="1168" alt="Schermata 2020-10-10 alle 12 01 59" src="https://user-images.githubusercontent.com/1730394/95652324-6e117a00-0af0-11eb-85f4-067ce091de6c.png">

**After:**
<img width="1212" alt="Schermata 2020-10-10 alle 12 03 05" src="https://user-images.githubusercontent.com/1730394/95652352-96997400-0af0-11eb-840d-1f1e883fa997.png">
