### PR TITLE
Add Solidus 2.11 versions to the security page

### DIFF
--- a/data/versions.yml
+++ b/data/versions.yml
@@ -1,5 +1,8 @@
 ---
 versions:
+  - number: v2.11
+    release_date: 2020-10-23
+    eol_date: 2022-04-23
   - number: v2.10
     release_date: 2020-01-15
     eol_date: 2021-07-15


### PR DESCRIPTION
I don't know how many versions we want to keep on the security page. 
For now, this PR adds the new Solidus 2.11 versions.