### PR TITLE
Add links to some extensions to the Features page

### DIFF
--- a/source/features.html.erb
+++ b/source/features.html.erb
@@ -128,7 +128,7 @@ description: Solidus can flex, adjust and extend as you deliver your customers a
             <div class="col-md">
               <h4>GraphQL API</h4>
               <p>
-                If you fancy GraphQL instead of REST, we have that too. Our GraphQL API allows you
+                If you fancy GraphQL instead of REST, we have that too. Our <a href="https://github.com/solidusio-contrib/solidus_graphql_api" target="_blank">GraphQL API</a> allows you
                 to access and replicate any aspects of the standard Solidus experience. Integrate it
                 with a React.js/Vue.js frontend to create an amazing storefront.
               </p>
@@ -157,7 +157,7 @@ description: Solidus can flex, adjust and extend as you deliver your customers a
           <img class="mb-5" src="<%= image_path('illustrations/features-payment_placeholder@2x.png') %>" data-src="<%= image_path('illustrations/features-payment.svg') %>" alt="Payment integrations" height="178" width="auto">
           <h4>Payment integrations</h4>
           <p>
-            Choose from dozens of payment processing services like Braintree, Stripe and PayPal. Our
+            Choose from dozens of payment processing services like <a href="https://github.com/solidusio/solidus_paypal_braintree" target="_blank">Braintree</a>, <a href="https://github.com/solidusio/solidus_stripe" target="_blank">Stripe</a> and <a href="https://github.com/solidusio-contrib/solidus_paypal_commerce_platform" target="_blank">PayPal</a>. Our
             extensions support hundreds of payment methods used internationally, including digital
             wallets such as Apple Pay and Google Pay.
           </p>


### PR DESCRIPTION
This PR adds the following links to some extensions mentioned on the [Features](https://solidus.io/features/) page:

- [GraphQL API](https://github.com/solidusio-contrib/solidus_graphql_api)
- [Braintree](https://github.com/solidusio/solidus_paypal_braintree)
- [Stripe](https://github.com/solidusio/solidus_stripe)
- [PayPal](https://github.com/solidusio-contrib/solidus_paypal_commerce_platform)