### PR TITLE
Prefer the <a> to set a wrapper as fully clickable

### DIFF
--- a/source/integrations.html.erb
+++ b/source/integrations.html.erb
@@ -45,16 +45,16 @@ description: Your eCommerce platform should expand your capabilities, not limit 
         <a class="btn btn-primary" href="/extensions#extensions-group-payments" target="_blank">View all Payments extensions</a>
       </div>
       <div class="integration__list col-lg offset-lg-1">
-        <div class="js-fully-clickable integration__list__item highlighted">
+        <a class="integration__list__item highlighted" href="https://github.com/solidusio-contrib/solidus_paypal_commerce_platform" target="_blank">
           <div class="integration__list__item__image">
             <%= inline_svg("integrations/paypal.svg", class: "isvg") %>
           </div>
           <div class="integration__list__item__description">
             <h4>PayPal</h4>
             <p>The official PayPal Commerce Platform integration of Solidus.</p>
-            <a href="https://github.com/solidusio-contrib/solidus_paypal_commerce_platform" target="_blank" class="btn btn-sm btn-white">Install the Official Gem</a>
+            <span class="btn btn-sm btn-white">Install the Official Gem</span>
           </div>
-        </div>
+        </a>
       </div>
     </div>
 


### PR DESCRIPTION
Since we need to track clicks on this wrapper: 
<img width="574" alt="Schermata 2020-10-30 alle 12 03 05" src="https://user-images.githubusercontent.com/46188345/97697836-e04dfc80-1aa7-11eb-9051-e16cceb4bd4e.png">

I've changed the tag of the wrapper with the `<a>` tag, instead of using the JS class `.js-fully-clickable`.
In this way, we'll be able to track all the clicks on this wrapper, on Google Analytics.