### PR TITLE
Create a recurring issue for updating stats

### DIFF
--- a/.github/ISSUE_TEMPLATE/monthly_stats.md
+++ b/.github/ISSUE_TEMPLATE/monthly_stats.md
@@ -1,0 +1,16 @@
+---
+name: Monthly Stats Update
+about: Template for creating the monthly stats update issue for the solidus.io website
+title: 'Update stats for {{.Year}}-{{.Month}}'
+labels: monthly-stats
+assignees: mfrecchiami
+---
+
+Update these stats on the website:
+
+* [GitHub Stars](https://github.com/solidusio/solidus/stargazers)
+* [Slack Members](http://slack.solidus.io/badge.svg)
+* [Contributors](https://github.com/solidusio/solidus/)
+* OC Donations - you need to be OC admin to do this
+
+To update the stats head to the [project_stats.yml](https://github.com/solidusio/solidus-site/blob/master/data/project_stats.yml) file.

--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -1,0 +1,28 @@
+name: monthly
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+
+jobs:
+  open-stats-update:
+    name: Open new stats update issue
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+      - uses: lowply/issue-from-template@v0.1.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IFT_TEMPLATE_NAME: monthly_stats.md
+
+  close-stats-update:
+    name: Close old stats update issues
+    needs: open-stats-update
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: lowply/auto-closer@v0.0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AC_LABEL: "monthly-stats"


### PR DESCRIPTION
This was previously done through IFFFT on a private account which is not ideal.

This does more or less the same thing by using GH Actions.

It will create only 1 issue maximum: it uses the "monthly-stats" label to remove old issues and create a new one.

Here is an example issue I created on a test repo: https://github.com/mtylty/recurring-issue-test/issues/46