### PR TITLE
Add solidus_feeds to the extension list

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -318,3 +318,8 @@ solidusio-contrib/solidus_klaviyo:
   title: Klaviyo
   description: Integrate with Klaviyo to automate email, SMS and social media marketing campaigns.
   group: Marketing
+solidusio-contrib/solidus_feeds:
+  ci_provider: circleci
+  title: Feeds
+  description: A framework for producing and publishing feeds on Solidus.
+  group: Omnichannel


### PR DESCRIPTION
As per the title, this adds [solidus_feeds](https://github.com/solidusio-contrib/solidus_feeds) to the list of extensions on the Solidus website, spearheading into Omnichannel territory.