### PR TITLE
Divide logos carousel by two rows

### DIFF
--- a/data/brands.yml
+++ b/data/brands.yml
@@ -171,13 +171,6 @@ firstleaf:
   industries:
     - food_beverage
 
-blue_apron:
-  name: "Blue Apron"
-  logo: "blue_apron.svg"
-  url: https://www.blueapron.com
-  industries:
-    - food_beverage
-
 moddedeuros:
   name: "ModdedEuros"
   logo: "moddedeuros.svg"
@@ -186,6 +179,13 @@ moddedeuros:
     - online_store
   industries:
     - automotive
+
+blue_apron:
+  name: "Blue Apron"
+  logo: "blue_apron.svg"
+  url: https://www.blueapron.com
+  industries:
+    - food_beverage
 
 tyres_direct:
   name: "Tyres Direct"

--- a/source/assets/javascripts/common.js
+++ b/source/assets/javascripts/common.js
@@ -155,12 +155,12 @@ $(function () {
   });
   
   $('.animated-logos.row-1').slick({
-    slidesToShow: 8,
+    slidesToShow: 10,
     slidesToScroll: 1,
     autoplay: true,
     infinite: true,
     autoplaySpeed: 0,
-    speed: 8000,
+    speed: 7800,
     arrows: false,
     dots: false,
     cssEase: 'linear',
@@ -188,12 +188,12 @@ $(function () {
   });
 
   $('.animated-logos.row-2').slick({
-    slidesToShow: 8,
+    slidesToShow: 9,
     slidesToScroll: 1,
     autoplay: true,
     infinite: true,
     autoplaySpeed: 0,
-    speed: 5000,
+    speed: 6800,
     arrows: false,
     dots: false,
     cssEase: 'linear',

--- a/source/assets/javascripts/common.js
+++ b/source/assets/javascripts/common.js
@@ -154,10 +154,11 @@ $(function () {
     fade: true
   });
   
-  $('.animated-logos').slick({
-    slidesToShow: 5,
+  $('.animated-logos.row-1').slick({
+    slidesToShow: 8,
     slidesToScroll: 1,
     autoplay: true,
+    infinite: true,
     autoplaySpeed: 0,
     speed: 8000,
     arrows: false,
@@ -167,15 +168,54 @@ $(function () {
     swipeToSlide: false,
     touchMove: false,
     pauseOnHover: false,
+    pauseOnFocus: false,
     responsive: [{
-        breakpoint: 768,
+        breakpoint: 1440,
+        settings: {
+            slidesToShow: 6
+        }
+    }, {
+        breakpoint: 1024,
         settings: {
             slidesToShow: 4
         }
     }, {
         breakpoint: 520,
         settings: {
-            slidesToShow: 2
+            slidesToShow: 3
+        }
+    }]
+  });
+
+  $('.animated-logos.row-2').slick({
+    slidesToShow: 8,
+    slidesToScroll: 1,
+    autoplay: true,
+    infinite: true,
+    autoplaySpeed: 0,
+    speed: 5000,
+    arrows: false,
+    dots: false,
+    cssEase: 'linear',
+    swipe: false,
+    swipeToSlide: false,
+    touchMove: false,
+    pauseOnHover: false,
+    pauseOnFocus: false,
+    responsive: [{
+      breakpoint: 1440,
+      settings: {
+          slidesToShow: 6
+      }
+    }, {
+        breakpoint: 1024,
+        settings: {
+            slidesToShow: 4
+        }
+    }, {
+        breakpoint: 520,
+        settings: {
+            slidesToShow: 3
         }
     }]
   });

--- a/source/assets/stylesheets/components/_misc.scss
+++ b/source/assets/stylesheets/components/_misc.scss
@@ -91,6 +91,16 @@
     padding: 0 $spacer;
     transform: scale(.9);
 
+    .carousel & {
+      transform: none;
+      max-width: 100%;
+      height: auto;
+
+      .isvg {
+        margin-top: 0;
+      }
+    }
+
     @include media-breakpoint-up(md){
       width: 15%;
       padding: 0;
@@ -118,7 +128,27 @@
     }
   }
   
-  .inherit-fill { fill: #505359; }
+  .inherit-fill { fill: $gray-500; }
+
+  &:not(.industries) {
+    .community-logos__item {
+      a:hover {
+        .inherit-fill {
+          fill: $gray-800;
+        }
+      }
+    }
+  }
+
+  &.industries {
+    .community-logos__item {
+      a:hover {
+        .inherit-fill {
+          fill: $white-048;
+        }
+      }
+    }
+  }
 }
 
 // Community logos animation

--- a/source/assets/stylesheets/components/_use-cases.scss
+++ b/source/assets/stylesheets/components/_use-cases.scss
@@ -47,10 +47,6 @@
       }
     }
   }
-
-  &.community-logos {
-    opacity: .65;
-  }
 }
 
 .use-cases-hero {

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -40,8 +40,8 @@ description: Solidus is the free, open-source eCommerce platform based on Ruby o
   <div class="intro content-block--skewed content-block-gray-100">
     <div class="content-wrapper pt-0 pb-0">
       <div class="content-block pt-0">
-        <div class="container">
-          <p class="lead text-gray-600 text-center font-weight-light mb-5">
+        <div class="container-fluid">
+          <p class="lead text-gray-600 text-center font-weight-light mb-md-8 mb-5">
             Solidus powers the brands defining the future of eCommerce.
           </p>
           <%= partial "partials/community_logos" %>

--- a/source/partials/_community_logos.html.erb
+++ b/source/partials/_community_logos.html.erb
@@ -1,6 +1,18 @@
 <div class="carousel col-lg-12">
-  <div class="animated-logos community-logos carousel__list">
-    <% data.brands.values.each do |brand| %>
+  <div class="animated-logos row-1 community-logos carousel__list">
+    <% data.brands.values.select { |brand| brand }.take(12).each do |brand| %>
+      <div class="community-logos__item">
+        <a href="<%= brand[:url] %>" target="_blank">
+          <%= inline_svg("community-logos/#{brand[:logo]}", class: "isvg") %>
+        </a>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class="carousel col-lg-12 mt-5">
+  <div class="animated-logos row-2 community-logos carousel__list">
+    <% data.brands.values.drop(12).each do |brand| %>
       <div class="community-logos__item">
         <a href="<%= brand[:url] %>" target="_blank">
           <%= inline_svg("community-logos/#{brand[:logo]}", class: "isvg") %>

--- a/source/partials/_community_logos.html.erb
+++ b/source/partials/_community_logos.html.erb
@@ -10,7 +10,7 @@
   </div>
 </div>
 
-<div class="carousel col-lg-12 mt-5">
+<div class="carousel col-lg-12 mt-3">
   <div class="animated-logos row-2 community-logos carousel__list">
     <% data.brands.values.drop(12).each do |brand| %>
       <div class="community-logos__item">


### PR DESCRIPTION
In this PR we're going to display the logos carousel on the homepage in two rows. A hover color has been added, also.

### Before
<img width="1787" alt="Screenshot 2021-05-11 at 09 38 20" src="https://user-images.githubusercontent.com/46188345/117777175-a15de800-b23c-11eb-9ed9-2409573db847.png">

### After
<img width="1782" alt="Screenshot 2021-05-11 at 09 38 08" src="https://user-images.githubusercontent.com/46188345/117777147-9a36da00-b23c-11eb-895b-bbe7ff269428.png">