### PR TITLE
Fix unclosed tag inside menu. Add miss transition

### DIFF
--- a/source/assets/stylesheets/components/_navigation.scss
+++ b/source/assets/stylesheets/components/_navigation.scss
@@ -248,7 +248,7 @@
         
         &.expandable {
           min-width: 1px;
-          transition: padding-right .2s ease;
+          transition: padding-right .2s ease, transform .3s linear;
           
           @include media-breakpoint-up(lg){
             &.expanded {

--- a/source/extensions.html.erb
+++ b/source/extensions.html.erb
@@ -77,7 +77,7 @@ description: Solidus provides a lot of free extensions. Fine-tune your store’s
       <div class="col-md">
         <div class="block-content mb-md-0">
           <h2 class="title">Build an extension.</h2>
-          <p>Don’t see the functionality you need? Create your own  extension and share it with the community so everyone can benefit from your expertise!</p>
+          <p>Don’t see the functionality you need? Create your own extension and share it with the community so everyone can benefit from your expertise!</p>
           <a class="btn btn-primary" href="https://github.com/solidusio/solidus_dev_support" target="_blank">Get Coding!</a>
         </div>
       </div>

--- a/source/partials/_header.erb
+++ b/source/partials/_header.erb
@@ -30,6 +30,7 @@
                   <a class="dropdown-item" href="/industries/food-and-beverage">Food and Beverage</a>
                 </div>
               </div>
+            </div>
           </div>
         </li>
 	      <li class="nav-item <%= nav_active("community.html") %>"><a href="/community">Community</a></li>


### PR DESCRIPTION
This PR fixes an unclosed tag inside the main menu and adds a missed transition effect when the Product dropdown menu appears.