### PR TITLE
Fix a broken community link in homepage

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -11,7 +11,8 @@ set :sass_assets_paths, ['.']
 set :seo_title, "Solidus: Rails eCommerce Platform"
 set :seo_description, "Build, customize and scale your store with no limits or license fees. Solidus is the free, open-source eCommerce framework for digitally-native brands, fast-growing online businesses and pragmatic developers."
 
-redirect "developers.html", to: "community.html"
+redirect "developers.html", to: "/contributors"
+redirect "community.html", to: "/contributors"
 
 activate :syntax
 

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -219,7 +219,7 @@ description: Solidus is the free, open-source eCommerce platform based on Ruby o
               <div class="mb-4">
                 <h4>Funded transparently</h4>
                 <p>
-                  Our <a href="/community"><b>community</b></a> supports Solidus with financial contributions through
+                  Our <a href="/contributors"><b>community</b></a> supports Solidus with financial contributions through
                   OpenCollective. The funds are used to improve and promote the platform.
                 </p>
               </div>


### PR DESCRIPTION
Also, this PR adds a redirect in case someone else was linking to our old community page, which does not exist anymore.

The broken link was here:

![CleanShot 2021-05-27 at 09 54 25@2x](https://user-images.githubusercontent.com/167946/119787495-8d1f1980-bed1-11eb-8130-6e0c5c85f6b8.png)
