### PR TITLE
Fix rendering of solidus_auth_devise name

### DIFF
--- a/source/blog/2021-11-17-GHSA-xm34-v85h-9pg2.html.markdown
+++ b/source/blog/2021-11-17-GHSA-xm34-v85h-9pg2.html.markdown
@@ -7,9 +7,9 @@ cover_image: /blog/shared/images/security.png
 description: New solidus_auth_devise & Solidus releases to address GHSA-xm34-v85h-9pg2. Please, update your store soon.
 ---
 
-We've released solidus_auth_devise [2.5.4](https://github.com/solidusio/solidus_auth_devise/releases/tag/v2.5.4) to address a security vulnerability (GHSA-xm34-v85h-9pg2) affecting all versions of solidus_auth_devise.
+We've released `solidus_auth_devise` [2.5.4](https://github.com/solidusio/solidus_auth_devise/releases/tag/v2.5.4) to address a security vulnerability (GHSA-xm34-v85h-9pg2) affecting all versions of `solidus_auth_devise`.
 
-We've also released Solidus [3.1.3](https://github.com/solidusio/solidus/releases/tag/v3.1.3), [3.0.3](https://github.com/solidusio/solidus/releases/tag/v3.0.3) and [2.11.12](https://github.com/solidusio/solidus/releases/tag/v2.11.12). They just contain a patch in case you're unable to update solidus_auth_devise.
+We've also released Solidus [3.1.3](https://github.com/solidusio/solidus/releases/tag/v3.1.3), [3.0.3](https://github.com/solidusio/solidus/releases/tag/v3.0.3) and [2.11.12](https://github.com/solidusio/solidus/releases/tag/v2.11.12). They just contain a patch in case you're unable to update `solidus_auth_devise`.
 
 You can read about GHSA-xm34-v85h-9pg2 on the [solidus mailing list](https://groups.google.com/forum/#!forum/solidus-security).
 


### PR DESCRIPTION
As the "auth" substring is surrounded by two "_", the markdown engine
was taking that as italic. We surround now with backquotes to make it
look like a code fragment, which is a convention we've been using on the
site.

This is how it looks before the fix:
![screenshot-solidus io-2021 11 26-06_10_02](https://user-images.githubusercontent.com/52650/143530107-52f364e2-d016-4e37-ab75-89bf1af51ef6.png)
