### PR TITLE
Add solidus_bolt extension

### DIFF
--- a/data/extensions.yml
+++ b/data/extensions.yml
@@ -323,3 +323,8 @@ solidusio-contrib/solidus_feeds:
   title: Feeds
   description: A framework for producing and publishing feeds on Solidus.
   group: Omnichannel
+solidusio-contrib/solidus_bolt:
+  ci_provider: circleci
+  title: Bolt
+  description: Let customers pay for their purchases over time by integrating with Bolt.
+  group: Payments


### PR DESCRIPTION
solidus_bolt is added on the extension page.
I didn't add it under the payments page because this page contains only certified extensions.